### PR TITLE
[Merged by Bors] - namespace fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+- Fixed a bug in the namespace resolution for the Init job that resulted in it not being triggered in non-default namespaces. ([#23]).
+
+[#23]: https://github.com/stackabletech/airflow-operator/pull/23
+
 ## [0.1.0] - 2022-02-03
 
 


### PR DESCRIPTION
## Description

Fix to namespace usage for the init-job (which checks the airflow db schema and adds an admin user): this was only working for the default namespace but not during kuttl integration testing where the init job was not being fired for non-default namespaces.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
