### PR TITLE
support specifying a namespace to watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.12.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.12.0#ac525b91421f7b0d4c74462627bf13e59be5661b"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#b895e632944ca98ea0e855d6782febcbba806aca"
 dependencies = [
  "backoff",
  "chrono",

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -1,0 +1,24 @@
+
+=== product-config
+
+*Default value*: `/etc/stackable/zookeeper-operator/config-spec/properties.yaml`
+
+*Required*: false
+
+*Multiple values:* false
+
+
+This file contains property definitions for the Apache Zookeeper configuration.
+
+=== watch-namespace
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will only watch for resources in the provided namespace `test`:
+
+[source]
+----
+cargo run -- run --watch-namespace=test
+----

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,0 +1,6 @@
+= Configuration
+
+== Command Line Parameters
+This operator accepts the following command line parameters:
+
+include::commandline_args.adoc[]

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.3.0-nightly"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 strum = { version = "0.23", features = ["derive"] }
 strum_macros = "0.23"
 

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -16,7 +16,7 @@ serde = "1.0"
 serde_yaml = "0.8"
 snafu = "0.7"
 stackable-airflow-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 strum = "0.23"
 strum_macros = "0.23"
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
@@ -25,4 +25,4 @@ tracing = "0.1"
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
 stackable-airflow-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -39,7 +39,10 @@ async fn main() -> anyhow::Result<()> {
             serde_yaml::to_string(&AirflowCluster::crd())?,
             serde_yaml::to_string(&Init::crd())?
         ),
-        Command::Run(ProductOperatorRun { product_config }) => {
+        Command::Run(ProductOperatorRun {
+            product_config,
+            watch_namespace,
+        }) => {
             stackable_operator::utils::print_startup_string(
                 built_info::PKG_DESCRIPTION,
                 built_info::PKG_VERSION,
@@ -57,12 +60,18 @@ async fn main() -> anyhow::Result<()> {
             ))
             .await?;
             let airflow_controller = Controller::new(
-                client.get_all_api::<AirflowCluster>(),
+                client.get_api::<AirflowCluster>(watch_namespace.as_deref()),
                 ListParams::default(),
             )
             .shutdown_on_signal()
-            .owns(client.get_all_api::<Service>(), ListParams::default())
-            .owns(client.get_all_api::<StatefulSet>(), ListParams::default())
+            .owns(
+                client.get_api::<Service>(watch_namespace.as_deref()),
+                ListParams::default(),
+            )
+            .owns(
+                client.get_api::<StatefulSet>(watch_namespace.as_deref()),
+                ListParams::default(),
+            )
             .run(
                 airflow_controller::reconcile_airflow,
                 airflow_controller::error_policy,
@@ -79,23 +88,21 @@ async fn main() -> anyhow::Result<()> {
                 );
             });
 
-            let init_controller =
-                Controller::new(client.get_all_api::<Init>(), ListParams::default())
-                    .shutdown_on_signal()
-                    .run(
-                        init_controller::reconcile_init,
-                        init_controller::error_policy,
-                        Context::new(init_controller::Ctx {
-                            client: client.clone(),
-                        }),
-                    )
-                    .map(|res| {
-                        report_controller_reconciled(
-                            &client,
-                            "inits.command.airflow.stackable.tech",
-                            &res,
-                        );
-                    });
+            let init_controller = Controller::new(
+                client.get_api::<Init>(watch_namespace.as_deref()),
+                ListParams::default(),
+            )
+            .shutdown_on_signal()
+            .run(
+                init_controller::reconcile_init,
+                init_controller::error_policy,
+                Context::new(init_controller::Ctx {
+                    client: client.clone(),
+                }),
+            )
+            .map(|res| {
+                report_controller_reconciled(&client, "inits.command.airflow.stackable.tech", &res);
+            });
 
             futures::stream::select(airflow_controller, init_controller)
                 .collect::<()>()


### PR DESCRIPTION
## Description

try
```
cargo run -- run --watch-namespace=test
```

fixes https://github.com/stackabletech/airflow-operator/issues/47

TODO:
- [ ] switch to tag

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
