### PR TITLE
[Merged by Bors] - Fix 1.59 clippy warnings

### DIFF
--- a/rust/operator-binary/src/init_controller.rs
+++ b/rust/operator-binary/src/init_controller.rs
@@ -221,9 +221,7 @@ async fn find_airflow_cluster_of_init_command(
     } = &init.spec.cluster_ref
     {
         let init_ns = init.namespace().unwrap_or_else(|| "default".to_string());
-        let airflow_ns = maybe_airflow_ns
-            .as_deref()
-            .unwrap_or_else(|| init_ns.as_str());
+        let airflow_ns = maybe_airflow_ns.as_deref().unwrap_or(init_ns.as_str());
         client
             .get::<AirflowCluster>(airflow_name, Some(airflow_ns))
             .await


### PR DESCRIPTION
## Description

Fixes Rust/Clippy 1.59 warnings

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
