### PR TITLE
[Merged by Bors] - Document support for Airflow 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Reconciliation errors are now reported as Kubernetes events ([#53]).
 - Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
   a single namespace to watch ([#54]).
+- Support for Airflow 2.2.4 documented ([#68]).
 
 ### Changed
 
@@ -17,6 +18,7 @@
 [#51]: https://github.com/stackabletech/airflow-operator/pull/51
 [#53]: https://github.com/stackabletech/airflow-operator/pull/53
 [#54]: https://github.com/stackabletech/airflow-operator/pull/54
+[#68]: https://github.com/stackabletech/airflow-operator/pull/68
 
 ## [0.2.0] - 2022-02-14
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -81,7 +81,7 @@ kind: AirflowCluster
 metadata:
   name: airflow
 spec:
-  version: 2.2.3-python3.8
+  version: 2.2.4-python3.9
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: true

--- a/docs/modules/ROOT/partials/supported-versions.adoc
+++ b/docs/modules/ROOT/partials/supported-versions.adoc
@@ -3,3 +3,4 @@
 // Stackable Platform documentation.
 
 - 2.2.3-python3.8
+- 2.2.4-python3.9

--- a/examples/simple-airflow-cluster.yaml
+++ b/examples/simple-airflow-cluster.yaml
@@ -29,7 +29,7 @@ kind: AirflowCluster
 metadata:
   name: airflow
 spec:
-  version: 2.2.3-python3.8
+  version: 2.2.4-python3.9
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: true

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -204,7 +204,7 @@ mod tests {
         metadata:
           name: airflow
         spec:
-          version: 2.2.3
+          version: 2.2.4
           executor: KubernetesExecutor
           loadExamples: true
           exposeConfig: true
@@ -227,7 +227,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!("2.2.3", cluster.spec.version.unwrap_or_default());
+        assert_eq!("2.2.4", cluster.spec.version.unwrap_or_default());
         assert_eq!(
             "KubernetesExecutor",
             cluster.spec.executor.unwrap_or_default()


### PR DESCRIPTION
## Description

Document support for Airflow 2.2.4

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

Closes #55

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
