### PR TITLE
[Merged by Bors] - Watch on AirflowDB init job on start-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@
 - Support for Airflow 2.2.4, 2.2.5 documented ([#68],[#84]).
 - Support for mounting DAGs via `ConfigMap` or `PersistentVolumeClaim` ([#84]).
 - Init job replaced with an AirflowDB resource created by the operator  ([#89]).
+- Stabilize start-up by watching AirflowDB job ([#104]).
 
 ### Changed
 
-- `operator-rs` `0.10.0` -> `0.18.0` ([#53],[#54],[#89]).
+- `operator-rs` `0.10.0` -> `0.19.0` ([#53],[#54],[#89]).
 
 [#51]: https://github.com/stackabletech/airflow-operator/pull/51
 [#53]: https://github.com/stackabletech/airflow-operator/pull/53
@@ -23,6 +24,7 @@
 [#68]: https://github.com/stackabletech/airflow-operator/pull/68
 [#84]: https://github.com/stackabletech/airflow-operator/pull/84
 [#89]: https://github.com/stackabletech/airflow-operator/pull/89
+[#104]: https://github.com/stackabletech/airflow-operator/pull/104
 
 ## [0.2.0] - 2022-02-14
 

--- a/tests/templates/kuttl/mount-dags-configmap/00-install-postgresql.yaml
+++ b/tests/templates/kuttl/mount-dags-configmap/00-install-postgresql.yaml
@@ -10,3 +10,4 @@ commands:
       --set auth.password=airflow
       --set auth.database=airflow
       --repo https://charts.bitnami.com/bitnami postgresql
+    timeout: 240

--- a/tests/templates/kuttl/mount-dags-configmap/03-assert.yaml
+++ b/tests/templates/kuttl/mount-dags-configmap/03-assert.yaml
@@ -12,10 +12,3 @@ metadata:
 status:
   readyReplicas: 1
   replicas: 1
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-metadata:
-  name: test-db-check
-commands:
-  - script: kubectl exec -n $NAMESPACE -c airflow airflow-scheduler-default-0 -- airflow db check-migrations

--- a/tests/templates/kuttl/mount-dags-pvc/00-install-postgresql.yaml
+++ b/tests/templates/kuttl/mount-dags-pvc/00-install-postgresql.yaml
@@ -10,3 +10,4 @@ commands:
       --set auth.password=airflow
       --set auth.database=airflow
       --repo https://charts.bitnami.com/bitnami postgresql
+    timeout: 240

--- a/tests/templates/kuttl/mount-dags-pvc/07-install-airflow-cluster.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-pvc/07-install-airflow-cluster.yaml.j2
@@ -28,18 +28,31 @@ spec:
   version: {{ test_scenario['values']['airflow'] }}
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
-  loadExamples: true
+  loadExamples: false
   exposeConfig: false
   credentialsSecret: test-airflow-credentials
+  volumes:
+    - name: external-dags
+      persistentVolumeClaim:
+        claimName: test-pvc-airflow
+  volumeMounts:
+    - name: external-dags
+      mountPath: /stackable/external-dags
   webservers:
     roleGroups:
       default:
+        envOverrides:
+          AIRFLOW__CORE__DAGS_FOLDER: "/stackable/external-dags"
         replicas: 1
   workers:
     roleGroups:
       default:
+        envOverrides:
+          AIRFLOW__CORE__DAGS_FOLDER: "/stackable/external-dags"
         replicas: 2
   schedulers:
     roleGroups:
       default:
+        envOverrides:
+          AIRFLOW__CORE__DAGS_FOLDER: "/stackable/external-dags"
         replicas: 1

--- a/tests/templates/kuttl/mount-dags-pvc/08-assert.yaml
+++ b/tests/templates/kuttl/mount-dags-pvc/08-assert.yaml
@@ -12,10 +12,3 @@ metadata:
 status:
   readyReplicas: 1
   replicas: 1
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-metadata:
-  name: test-db-check
-commands:
-  - script: kubectl exec -n $NAMESPACE -c airflow airflow-scheduler-default-0 -- airflow db check-migrations

--- a/tests/templates/kuttl/smoke/00-install-postgresql.yaml
+++ b/tests/templates/kuttl/smoke/00-install-postgresql.yaml
@@ -10,3 +10,4 @@ commands:
       --set auth.password=airflow
       --set auth.database=airflow
       --repo https://charts.bitnami.com/bitnami postgresql
+    timeout: 240

--- a/tests/templates/kuttl/smoke/03-assert.yaml
+++ b/tests/templates/kuttl/smoke/03-assert.yaml
@@ -12,10 +12,3 @@ metadata:
 status:
   readyReplicas: 1
   replicas: 1
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-metadata:
-  name: test-db-check
-commands:
-  - script: kubectl exec -n $NAMESPACE -c airflow airflow-scheduler-default-0 -- airflow db check-migrations


### PR DESCRIPTION
# Description

Add a watch in the AirflowDB init job so that the airflow roles are not started unless this job is completed. Fixed the DAGs-PVC test.
Fixes #98.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
