### PR TITLE
[Merged by Bors] - Change code to adhere to ADR18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 
 ### Changed
 
-- `operator-rs` `0.10.0` -> `0.19.0` ([#53],[#54],[#89]).
 - `operator-rs` `0.10.0` -> `0.18.0` ([#53],[#54],[#89]).
 - [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#106])
 
@@ -26,8 +25,8 @@
 [#68]: https://github.com/stackabletech/airflow-operator/pull/68
 [#84]: https://github.com/stackabletech/airflow-operator/pull/84
 [#89]: https://github.com/stackabletech/airflow-operator/pull/89
-[#106]: https://github.com/stackabletech/airflow-operator/pull/106
 [#104]: https://github.com/stackabletech/airflow-operator/pull/104
+[#106]: https://github.com/stackabletech/airflow-operator/pull/106
 
 ## [0.2.0] - 2022-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 - `operator-rs` `0.10.0` -> `0.18.0` ([#53],[#54],[#89]).
+- [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#xxx])
 
 [#51]: https://github.com/stackabletech/airflow-operator/pull/51
 [#53]: https://github.com/stackabletech/airflow-operator/pull/53
@@ -23,6 +24,7 @@
 [#68]: https://github.com/stackabletech/airflow-operator/pull/68
 [#84]: https://github.com/stackabletech/airflow-operator/pull/84
 [#89]: https://github.com/stackabletech/airflow-operator/pull/89
+[#xxx]: https://github.com/stackabletech/airflow-operator/pull/xxx
 
 ## [0.2.0] - 2022-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Changed
 
 - `operator-rs` `0.10.0` -> `0.18.0` ([#53],[#54],[#89]).
-- [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#xxx])
+- [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#106])
 
 [#51]: https://github.com/stackabletech/airflow-operator/pull/51
 [#53]: https://github.com/stackabletech/airflow-operator/pull/53
@@ -24,7 +24,7 @@
 [#68]: https://github.com/stackabletech/airflow-operator/pull/68
 [#84]: https://github.com/stackabletech/airflow-operator/pull/84
 [#89]: https://github.com/stackabletech/airflow-operator/pull/89
-[#xxx]: https://github.com/stackabletech/airflow-operator/pull/xxx
+[#106]: https://github.com/stackabletech/airflow-operator/pull/106
 
 ## [0.2.0] - 2022-02-14
 

--- a/docs/modules/ROOT/examples/example-airflow-dags-configmap.yaml
+++ b/docs/modules/ROOT/examples/example-airflow-dags-configmap.yaml
@@ -4,7 +4,7 @@ kind: AirflowCluster
 metadata:
   name: airflow
 spec:
-  version: 2.2.5-python39
+  version: 2.2.5-python39-stackable0.3.0
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: false

--- a/docs/modules/ROOT/examples/example-airflow-dags-pvc.yaml
+++ b/docs/modules/ROOT/examples/example-airflow-dags-pvc.yaml
@@ -4,7 +4,7 @@ kind: AirflowCluster
 metadata:
   name: airflow
 spec:
-  version: 2.2.4-python39
+  version: 2.2.4-python39-stackable0.3.0
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: false

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -81,7 +81,7 @@ kind: AirflowCluster
 metadata:
   name: airflow
 spec:
-  version: 2.2.4-python3.9
+  version: 2.2.4-python3.9-stackable0.3.0
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: true
@@ -100,6 +100,11 @@ spec:
       default:
         replicas: 1
 ----
+
+Please note that the version you need to specify is not only the version of Airflow which you want to roll out, but has to be amended with a Stackable version as shown.
+This Stackable version is the version of the underlying container image which is used to execute the processes.
+For a list of available versions please check our https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable%2Fairflow%2Ftags[image registry].
+It should generally be safe to simply use the latest image version that is available.
 
 Where:
 

--- a/examples/simple-airflow-cluster-dags-cmap.yaml
+++ b/examples/simple-airflow-cluster-dags-cmap.yaml
@@ -80,7 +80,7 @@ kind: AirflowCluster
 metadata:
   name: airflow-dags-cmap
 spec:
-  version: 2.2.5-python39
+  version: 2.2.5-python39-stackable0.3.0
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: false

--- a/examples/simple-airflow-cluster-dags-pvc.yaml
+++ b/examples/simple-airflow-cluster-dags-pvc.yaml
@@ -20,7 +20,7 @@ kind: AirflowCluster
 metadata:
   name: airflow-dags-pvc
 spec:
-  version: 2.2.4-python39
+  version: 2.2.4-python39-stackable0.3.0
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: false

--- a/examples/simple-airflow-cluster.yaml
+++ b/examples/simple-airflow-cluster.yaml
@@ -20,7 +20,7 @@ kind: AirflowCluster
 metadata:
   name: airflow
 spec:
-  version: 2.2.3-python38
+  version: 2.2.3-python38-stackable0.3.0
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: true

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -285,7 +285,7 @@ fn build_server_rolegroup_statefulset(
 
     let rolegroup = role.role_groups.get(&rolegroup_ref.role_group);
 
-    let image = format!("docker.stackable.tech/stackable/airflow:{airflow_version}-stackable0",);
+    let image = format!("docker.stackable.tech/stackable/airflow:{airflow_version}",);
     tracing::info!("Using image {}", image);
 
     let statsd_exporter_version = statsd_exporter_version(airflow)?;

--- a/rust/operator-binary/src/airflow_db_controller.rs
+++ b/rust/operator-binary/src/airflow_db_controller.rs
@@ -188,7 +188,7 @@ fn build_init_job(airflow_db: &AirflowDB) -> Result<Job> {
 
     let container = ContainerBuilder::new("airflow-init-db")
         .image(format!(
-            "docker.stackable.tech/stackable/airflow:{}-stackable0",
+            "docker.stackable.tech/stackable/airflow:{}",
             airflow_db.spec.airflow_version
         ))
         .command(vec!["/bin/bash".to_string()])

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,9 +2,9 @@
 dimensions:
   - name: airflow
     values:
-      - 2.2.3-python38
-      - 2.2.4-python39
-      - 2.2.5-python39
+      - 2.2.3-python38-stackable0.3.0
+      - 2.2.4-python39-stackable0.3.0
+      - 2.2.5-python39-stackable0.3.0
 tests:
   - name: smoke
     dimensions:


### PR DESCRIPTION
# Description
This contains a breaking change, since the version that is specified for Airflow now has to include a stackable image version.

Previously the version could be specified as "version: 3.2.1" and the operator simply added the stackable version to this. But going forward we have decided that the image version has to be explictly specified, so it will now have to be "version: 3.2.1-stackable-0.1.0" or similar.

This is in accordance with ADR18 (https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html).

*Please add a description here. This will become the commit message of the merge request later.*

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
