### PR TITLE
test: Add readinessProbe to openldap to reduce test failures

### DIFF
--- a/tests/templates/kuttl/ldap/02-install-openldap.yaml
+++ b/tests/templates/kuttl/ldap/02-install-openldap.yaml
@@ -54,6 +54,9 @@ spec:
           volumeMounts:
             - name: tls
               mountPath: /tls
+          readinessProbe:
+            tcpSocket:
+              port: 1389
       volumes:
         - name: tls
           csi:


### PR DESCRIPTION
# Description

Same as https://github.com/stackabletech/superset-operator/pull/260

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
