### PR TITLE
[Merged by Bors] - Check and correct docs following release

### DIFF
--- a/docs/modules/getting_started/examples/code/getting_started.sh
+++ b/docs/modules/getting_started/examples/code/getting_started.sh
@@ -39,18 +39,18 @@ helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
 # end::helm-add-repo[]
 echo "Installing Operators with Helm"
 # tag::helm-install-operators[]
-helm install --wait commons-operator stackable-dev/commons-operator --version 0.3.0-nightly
-helm install --wait secret-operator stackable-dev/secret-operator --version 0.6.0-nightly
-helm install --wait airflow-operator stackable-dev/airflow-operator --version 0.5.0-nightly
+helm install --wait commons-operator stackable-dev/commons-operator --version 0.3.0
+helm install --wait secret-operator stackable-dev/secret-operator --version 0.5.0
+helm install --wait airflow-operator stackable-dev/airflow-operator --version 0.5.0
 # end::helm-install-operators[]
 ;;
 "stackablectl")
 echo "installing Operators with stackablectl"
 # tag::stackablectl-install-operators[]
 stackablectl operator install \
-  commons=0.3.0-nightly \
-  secret=0.6.0-nightly \
-  airflow=0.5.0-nightly
+  commons=0.3.0 \
+  secret=0.5.0 \
+  airflow=0.5.0
 # end::stackablectl-install-operators[]
 ;;
 *)

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -3,8 +3,8 @@ helm:
   repo_name: stackable-dev
   repo_url: https://repo.stackable.tech/repository/helm-dev/
 versions:
-  commons: 0.4.0-nightly
-  secret: 0.6.0-nightly
-  airflow: 0.6.0-nightly
+  commons: 0.3.0
+  secret: 0.5.0
+  airflow: 0.5.0
   postgresql: 11.0.0
   redis: 16.8.7


### PR DESCRIPTION
# Description

Set `templating_vars.yaml` to use stable versions from release and ran `docs_templating.sh` to update `getting_started.sh`. This change should then be tagged with `docs/0.5` and a subsequent PR will be needed to replace the stable versions with the current nightly ones.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
