### PR TITLE
[Merged by Bors] - fixed operator warnings on open-shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Changed
 
+- Specified security context settings needed for OpenShift ([#222]).
+- Fixed template parsing for OpenShift tests ([#222]).
+
+[#222]: https://github.com/stackabletech/airflow-operator/pull/222
+
+## [23.1.0] - 2023-01-23
+
+### Changed
+
 - `operator-rs` `0.25.2` -> `0.27.1` ([#197]).
 - `operator-rs` `0.27.1` -> `0.30.1` ([#208])
 - `operator-rs` `0.30.1` -> `0.31.0` ([#216]).

--- a/deploy/helm/airflow-operator/values.yaml
+++ b/deploy/helm/airflow-operator/values.yaml
@@ -26,11 +26,13 @@ securityContext:
   capabilities:
     drop:
     - ALL
-  runAsNonRoot: true
   allowPrivilegeEscalation: false
   seccompProfile:
     type: RuntimeDefault
   # readOnlyRootFilesystem: true
+  # openshift requires a UID if one is not given in the image definition (e.g. "stackable")
+  # to verify that the user is non-root
+  runAsNonRoot: true
   runAsUser: 1000
 
 resources: {}

--- a/deploy/helm/airflow-operator/values.yaml
+++ b/deploy/helm/airflow-operator/values.yaml
@@ -22,13 +22,16 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  runAsUser: 1000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,16 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,11 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/ldap/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/ldap/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,32 @@ volumePermissions:
 
 master:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/ldap/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/ldap/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,22 @@ volumePermissions:
 
 master:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,16 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,11 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,32 @@ volumePermissions:
 
 master:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,22 @@ volumePermissions:
 
 master:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,16 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,11 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,32 @@ volumePermissions:
 
 master:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-pvc/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,22 @@ volumePermissions:
 
 master:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/orphaned-resources/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,16 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/orphaned-resources/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,11 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/orphaned-resources/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,32 @@ volumePermissions:
 
 master:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/orphaned-resources/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,22 @@ volumePermissions:
 
 master:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,16 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,11 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/resources/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/resources/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,32 @@ volumePermissions:
 
 master:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/resources/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/resources/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,22 @@ volumePermissions:
 
 master:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,16 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+    
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
@@ -6,7 +6,7 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {% if test_scenario['values']['openshift'] == 'true' -%}
     enabled: false
 {% else %}
     enabled: true

--- a/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
@@ -6,11 +6,11 @@ volumePermissions:
 
 primary:
   podSecurityContext:
-    {% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
@@ -6,7 +6,7 @@ volumePermissions:
 
 master:
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {% if test_scenario['values']['openshift'] == 'true' -%}
     enabled: false
 {% else %}
     enabled: true
@@ -17,7 +17,7 @@ master:
 replica:
   replicaCount: 1
   podSecurityContext:
-{% if test_scenario['values']['openshift'] == 'true' -%}
+    {% if test_scenario['values']['openshift'] == 'true' -%}
     enabled: false
 {% else %}
     enabled: true

--- a/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,32 @@ volumePermissions:
 
 master:
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-    {%- if test_scenario['values']['openshift'] == 'true' +%}
+    {%- if test_scenario['values']['openshift'] == 'true' %}
+
     enabled: false
-    {%- else +%}
+
+    {%- else %}
+
     enabled: true
-    {%- endif +%}
+
+    {%- endif %}
+
   containerSecurityContext:
     enabled: false
 

--- a/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
@@ -6,22 +6,22 @@ volumePermissions:
 
 master:
   podSecurityContext:
-    {% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 
 replica:
   replicaCount: 1
   podSecurityContext:
-    {% if test_scenario['values']['openshift'] == 'true' -%}
+    {%- if test_scenario['values']['openshift'] == 'true' +%}
     enabled: false
-{% else %}
+    {%- else +%}
     enabled: true
-{% endif %}
+    {%- endif +%}
   containerSecurityContext:
     enabled: false
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -11,12 +11,12 @@
 dimensions:
   - name: airflow
     values:
-      - 2.2.4-stackable0.5.0
-      - 2.2.5-stackable0.5.0
-      - 2.4.1-stackable0.7.0
+      - 2.2.4-stackable23.1
+      - 2.2.5-stackable23.1
+      - 2.4.1-stackable23.1
   - name: airflow-latest
     values:
-      - 2.4.1-stackable0.7.0
+      - 2.4.1-stackable23.1
   - name: ldap-authentication
     values:
       - no-tls


### PR DESCRIPTION
# Description

Stricter operator image security settings to deal with startup warnings when running in open-shift, plus changes to jinja2 parsing to work in openshift and non-openshift cases.

Jenkins :heavy_check_mark: : https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/airflow-operator-it-custom/67/

N.B. using the "+" operator with jinja2 would make the templates much cleaner, but this does not work on Jenkins. This may no longer be relevant once we have switched over to using beku.py.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
