### PR TITLE
[Merged by Bors] - BUGFIX: Revert openshift-specific settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 ### Changed
 
 - `operator-rs` `0.31.0` -> `0.34.0` ([#219]).
+- Revert openshift settings ([#xxx])
 
 [#219]: https://github.com/stackabletech/airflow-operator/pull/219
+[#xxx]: https://github.com/stackabletech/spark-k8s-operator/pull/xxx
 
 ## [23.1.0] - 2023-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 ### Changed
 
 - `operator-rs` `0.31.0` -> `0.34.0` ([#219]).
-- Revert openshift settings ([#xxx])
+- Revert openshift settings ([#233])
 
 [#219]: https://github.com/stackabletech/airflow-operator/pull/219
-[#xxx]: https://github.com/stackabletech/spark-k8s-operator/pull/xxx
+[#233]: https://github.com/stackabletech/spark-k8s-operator/pull/233
 
 ## [23.1.0] - 2023-01-23
 

--- a/deploy/helm/airflow-operator/values.yaml
+++ b/deploy/helm/airflow-operator/values.yaml
@@ -22,18 +22,7 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  capabilities:
-    drop:
-    - ALL
-  allowPrivilegeEscalation: false
-  seccompProfile:
-    type: RuntimeDefault
-  # readOnlyRootFilesystem: true
-  # openshift requires a UID if one is not given in the image definition (e.g. "stackable")
-  # to verify that the user is non-root
-  runAsNonRoot: true
-  runAsUser: 1000
+securityContext: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
# Description

Openshift-specific settings are no longer needed as operators will be packaged with olm for OS clusters.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
