### PR TITLE
[Merged by Bors] - Add missing crd defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Generate OLM bundle for Release 23.4.0 ([#270]).
 - Fix LDAP tests for Openshift ([#270]).
+- Missing CRD defaults for `status.conditions` field ([#277]).
 
 ### Changed
 
@@ -18,6 +19,7 @@
 [#271]: https://github.com/stackabletech/airflow-operator/pull/271
 [#272]: https://github.com/stackabletech/airflow-operator/pull/272
 [#274]: https://github.com/stackabletech/airflow-operator/pull/274
+[#277]: https://github.com/stackabletech/airflow-operator/pull/277
 
 ## [23.4.0] - 2023-04-17
 

--- a/deploy/helm/airflow-operator/crds/crds.yaml
+++ b/deploy/helm/airflow-operator/crds/crds.yaml
@@ -5183,6 +5183,7 @@ spec:
               nullable: true
               properties:
                 conditions:
+                  default: []
                   items:
                     properties:
                       lastTransitionTime:
@@ -5224,8 +5225,6 @@ spec:
                       - type
                     type: object
                   type: array
-              required:
-                - conditions
               type: object
           required:
             - spec

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -547,6 +547,7 @@ impl Configuration for AirflowConfigFragment {
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AirflowClusterStatus {
+    #[serde(default)]
     pub conditions: Vec<ClusterCondition>,
 }
 


### PR DESCRIPTION
# Description

Due to breaking changes in with the clusterConfig the CRD replace still works but the operator throws an error:
```
2023-05-12T08:51:04.696282Z ERROR stackable_operator::logging::controller: Failed to reconcile object controller.name="airflowcluster.airflow.stackable.tech" error=event queue error error.sources=[fa
iled to perform initial object list: Error deserializing response, Error deserializing response, missing field `credentialsSecret` at line 1 column 5264]
```
This will be gone when applying a new correct CR.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
