### PR TITLE
[Merged by Bors] - Added kuttl test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `operator-rs` `0.40.2` -> `0.41.0` ([#272]).
 - Use 0.0.0-dev product images for testing ([#274])
 - Use testing-tools 0.2.0 ([#274])
+- Added kuttl test suites ([#291])
 
 [#270]: https://github.com/stackabletech/airflow-operator/pull/270
 [#271]: https://github.com/stackabletech/airflow-operator/pull/271
@@ -22,6 +23,7 @@
 [#274]: https://github.com/stackabletech/airflow-operator/pull/274
 [#277]: https://github.com/stackabletech/airflow-operator/pull/277
 [#284]: https://github.com/stackabletech/airflow-operator/pull/284
+[#291]: https://github.com/stackabletech/airflow-operator/pull/291
 
 ## [23.4.0] - 2023-04-17
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -71,4 +71,3 @@ suites:
       - dimensions:
           - name: openshift
             expr: "true"
-

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -56,3 +56,19 @@ tests:
     dimensions:
       - airflow-latest
       - openshift
+suites:
+  - name: latest
+    patch:
+      - dimensions:
+          - expr: last
+  - name: smoke
+    select:
+      - smoke
+  - name: openshift
+    patch:
+      - dimensions:
+          - expr: last
+      - dimensions:
+          - name: openshift
+            expr: "true"
+


### PR DESCRIPTION

# Description

Requires `beku 0.0.7`. Upgrade with:

```
pip install --upgrade beku-stackabletech
```

Added three test suites:

* `latest` : only run tests with the latest versions.
* `smoke` : only run smoke tests.
* `openshift` : only run latest versions with openshift=true.

To  run the `latest` test suite:

```
rm -rf tests/_work && beku -s latest
```


<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
