### PR TITLE
[Merged by Bors] - fix: Increase webserver default memory limit to 2Gi

### DIFF
--- a/docs/modules/airflow/pages/usage-guide/storage-resources.adoc
+++ b/docs/modules/airflow/pages/usage-guide/storage-resources.adoc
@@ -2,7 +2,7 @@
 
 include::home:concepts:stackable_resource_requests.adoc[]
 
-A minimal HA setup consisting of 2 schedules, 2 workers and 2 webservers has the following https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requirements]:
+A minimal HA setup consisting of 2 schedulers, 2 workers and 2 webservers has the following https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requirements]:
 
 * `3500m` CPU request
 * `8600m` CPU limit

--- a/docs/modules/airflow/pages/usage-guide/storage-resources.adoc
+++ b/docs/modules/airflow/pages/usage-guide/storage-resources.adoc
@@ -2,11 +2,11 @@
 
 include::home:concepts:stackable_resource_requests.adoc[]
 
-A minimal HA setup consisting of 2 Airflow instances has the following https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requirements]:
+A minimal HA setup consisting of 2 schedules, 2 workers and 2 webservers has the following https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requirements]:
 
 * `3500m` CPU request
 * `8600m` CPU limit
-* `8108Mi` memory request and limit
+* `10156Mi` memory request and limit
 
 Corresponding to the values above, the operator uses the following resource defaults:
 
@@ -36,5 +36,5 @@ spec:
           min: 100m
           max: 400m
         memory:
-          limit: 1024Mi
+          limit: 2Gi
 ----

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -505,7 +505,7 @@ impl AirflowConfig {
                     max: Some(Quantity("400m".into())),
                 },
                 MemoryLimitsFragment {
-                    limit: Some(Quantity("1024Mi".into())),
+                    limit: Some(Quantity("2Gi".into())),
                     runtime_limits: NoRuntimeLimitsFragment {},
                 },
             ),


### PR DESCRIPTION
# Description

With `1 Gi` the webserver keep crashing randomly due to memory problems, even with a single, really really small DAG

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
