### PR TITLE
Removed check for InitDb logs

### DIFF
--- a/tests/templates/kuttl/logging/airflow-vector-aggregator-values.yaml.j2
+++ b/tests/templates/kuttl/logging/airflow-vector-aggregator-values.yaml.j2
@@ -92,10 +92,6 @@ customConfig:
       condition: >-
         .pod == "airflow-scheduler-custom-log-config-0" &&
         .container == "vector"
-    filteredAutomaticLogConfigInitDb:
-      type: filter
-      inputs: [vector]
-      condition: .container == "airflow-init-db"
     filteredInvalidEvents:
       type: filter
       inputs: [vector]


### PR DESCRIPTION
In addition to https://github.com/stackabletech/airflow-operator/pull/322:
One of the nightly tests was failing, because it checked the InitDb logs, which are now part of the scheduler log and not their own log anymore. I removed this part of the test.

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
