### PR TITLE
Upgrade Vector to version 0.33.0 in the tests

### DIFF
--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1189,14 +1189,7 @@ fn build_template_envs(
     airflow: &AirflowCluster,
     env_overrides: &HashMap<String, String>,
 ) -> Vec<EnvVar> {
-    let secret_prop = Some(
-        airflow
-            .spec
-            .cluster_config
-            .credentials_secret
-            .as_str()
-            .clone(),
-    );
+    let secret_prop = Some(airflow.spec.cluster_config.credentials_secret.as_str());
 
     let mut env = secret_prop
         .map(|secret| {

--- a/tests/templates/kuttl/logging/03-install-airflow-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/03-install-airflow-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.23.0
+      --version 0.26.0
       --repo https://helm.vector.dev
       --values airflow-vector-aggregator-values.yaml
 ---


### PR DESCRIPTION
# Description

* Upgrade Vector to version 0.33.0 in the tests, which is provided by the Vector Helm chart version 0.26.0.
* Fix Clippy warnings

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
