### PR TITLE
Fix pod template envvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - BREAKING: Fixed various issues in the CRD structure. `clusterConfig.credentialsSecret` is now mandatory ([#353]).
+- Fixed ordering of variables written to the kubernetes executor pod template ([#372]).
 
 ### Removed
 
@@ -25,6 +26,7 @@
 [#353]: https://github.com/stackabletech/airflow-operator/pull/353
 [#354]: https://github.com/stackabletech/airflow-operator/pull/354
 [#366]: https://github.com/stackabletech/airflow-operator/pull/366
+[#372]: https://github.com/stackabletech/airflow-operator/pull/372
 
 ## [23.11.0] - 2023-11-24
 

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1331,7 +1331,8 @@ fn build_template_envs(
         ..Default::default()
     });
 
-    for (k, v) in env_overrides {
+    // iterate over a BTreeMap to ensure the vars are written in a predictable order
+    for (k, v) in env_overrides.iter().collect::<BTreeMap<_, _>>() {
         env.push(EnvVar {
             name: k.to_string(),
             value: Some(v.to_string()),


### PR DESCRIPTION
# Description

See https://github.com/stackabletech/airflow-operator/issues/371.
The `envOverrides` entries are added to the config-map for the `kubernetesExecutor` pod template by iterating over a `HashMap`: this leads to a unpredictable order and unnecessary restarts of airflow components. The `HashMap` is converted to a `BTreeMap` to avoid this happening.

:green_circle: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/airflow-operator-it-custom/121/

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes) https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/airflow-operator-it-custom/121/
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
