### PR TITLE
docs: Add usage guide on Kubernetes executors

### DIFF
--- a/docs/modules/airflow/pages/usage-guide/logging.adoc
+++ b/docs/modules/airflow/pages/usage-guide/logging.adoc
@@ -17,7 +17,7 @@ spec:
             loggers:
               "flask_appbuilder":
                 level: WARN
-  workers:
+  celeryExecutors:
     config:
       logging:
         enableVectorAgent: true

--- a/docs/modules/airflow/pages/usage-guide/storage-resources.adoc
+++ b/docs/modules/airflow/pages/usage-guide/storage-resources.adoc
@@ -21,7 +21,7 @@ spec:
           max: "2"
         memory:
           limit: 512Mi
-  workers:
+  celeryExecutors:
     config:
       resources:
         cpu:

--- a/docs/modules/airflow/pages/usage-guide/using-kubernetes-executors.adoc
+++ b/docs/modules/airflow/pages/usage-guide/using-kubernetes-executors.adoc
@@ -1,0 +1,29 @@
+= Using Kubernetes executors
+
+Instead of using the Celery workers you can let Airflow run the tasks using Kubernetes executors, where pods are created dynamically as needed without jobs being routed through a redis queue to the workers.
+
+To achieve this, swap `spec.celeryExecutors` with `spec.kubernetesExecutors`.
+E.g. you would change the following example
+
+[source,yaml]
+----
+spec:
+  celeryExecutors:
+    roleGroups:
+      default:
+        replicas: 2
+    config:
+      resources:
+        # ...
+----
+
+to
+
+[source,yaml]
+----
+spec:
+  kubernetesExecutors:
+    config:
+      resources:
+        # ...
+----

--- a/docs/modules/airflow/partials/nav.adoc
+++ b/docs/modules/airflow/partials/nav.adoc
@@ -10,6 +10,7 @@
 ** xref:airflow:usage-guide/security.adoc[]
 ** xref:airflow:usage-guide/logging.adoc[]
 ** xref:airflow:usage-guide/monitoring.adoc[]
+** xref:airflow:usage-guide/using-kubernetes-executors.adoc[]
 ** xref:airflow:usage-guide/overrides.adoc[]
 ** xref:airflow:usage-guide/operations/index.adoc[]
 *** xref:airflow:usage-guide/operations/cluster-operations.adoc[]


### PR DESCRIPTION
# Description
Fixes https://github.com/stackabletech/airflow-operator/issues/370 (all `grep -r 'workers:'` findings fixed)

Previously it was only at https://docs.stackable.tech/home/stable/airflow/ and IMHO hard to find

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
