### PR TITLE
fix: Run git-sync as one-time call with KubernetesExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - BREAKING: Fixed various issues in the CRD structure. `clusterConfig.credentialsSecret` is now mandatory ([#353]).
 - Fixed ordering of variables written to the kubernetes executor pod template ([#372]).
+- Fixed git-sync container running with KubernetesExecutor ([#381]).
 
 ### Removed
 
@@ -29,6 +30,7 @@
 [#366]: https://github.com/stackabletech/airflow-operator/pull/366
 [#372]: https://github.com/stackabletech/airflow-operator/pull/372
 [#374]: https://github.com/stackabletech/airflow-operator/pull/374
+[#381]: https://github.com/stackabletech/airflow-operator/pull/381
 
 ## [23.11.0] - 2023-11-24
 

--- a/rust/crd/src/git_sync.rs
+++ b/rust/crd/src/git_sync.rs
@@ -29,7 +29,13 @@ pub struct GitSync {
     /// Read the [git sync example](DOCS_BASE_URL_PLACEHOLDER/airflow/usage-guide/mounting-dags#_example).
     pub git_sync_conf: Option<BTreeMap<String, String>>,
 }
+
 impl GitSync {
+    /// Returns the command arguments for calling git-sync. If git-sync is called when using the
+    /// KubernetesExecutor it should only be called once, and from an initContainer; otherwise, the container
+    /// is not terminated and the job can not be cleaned up properly (the job/task is created by airflow from
+    /// a pod template and is terminated by airflow itself). The `one_time` parameter is used
+    /// to indicate this.
     pub fn get_args(&self, one_time: bool) -> Vec<String> {
         let mut git_config = format!("{GIT_SAFE_DIR}:{GIT_ROOT}");
         let mut git_sync_command = vec![

--- a/rust/crd/src/git_sync.rs
+++ b/rust/crd/src/git_sync.rs
@@ -5,7 +5,7 @@ use stackable_operator::{
 };
 use std::collections::BTreeMap;
 
-use crate::{AirflowExecutor, GIT_LINK, GIT_ROOT, GIT_SAFE_DIR, GIT_SYNC_DEPTH, GIT_SYNC_WAIT};
+use crate::{GIT_LINK, GIT_ROOT, GIT_SAFE_DIR, GIT_SYNC_DEPTH, GIT_SYNC_WAIT};
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -182,7 +182,7 @@ mod tests {
         assert!(cluster
             .git_sync()
             .unwrap()
-            .get_args()
+            .get_args(false)
             .iter()
             .any(|c| c.contains("--rev=c63921857618a8c392ad757dda13090fff3d879a")));
     }
@@ -256,7 +256,7 @@ mod tests {
         assert!(cluster
             .git_sync()
             .unwrap()
-            .get_args()
+            .get_args(false)
             .iter()
             .any(|c| c.contains(output)));
     }

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1126,9 +1126,7 @@ fn build_executor_template_config_map(
                 "pipefail".to_string(),
                 "-c".to_string(),
             ])
-            .args(vec![gitsync
-                .get_args(true)
-                .join("\n")])
+            .args(vec![gitsync.get_args(true).join("\n")])
             .add_volume_mount(GIT_CONTENT, GIT_ROOT)
             .resources(
                 ResourceRequirementsBuilder::new()

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -940,7 +940,7 @@ fn build_server_rolegroup_statefulset(
                 "pipefail".to_string(),
                 "-c".to_string(),
             ])
-            .args(vec![gitsync.get_args().join("\n")])
+            .args(vec![gitsync.get_args(false).join("\n")])
             .add_volume_mount(GIT_CONTENT, GIT_ROOT)
             .resources(
                 ResourceRequirementsBuilder::new()
@@ -1126,7 +1126,9 @@ fn build_executor_template_config_map(
                 "pipefail".to_string(),
                 "-c".to_string(),
             ])
-            .args(vec![gitsync.get_args().join("\n")])
+            .args(vec![gitsync
+                .get_args(true)
+                .join("\n")])
             .add_volume_mount(GIT_CONTENT, GIT_ROOT)
             .resources(
                 ResourceRequirementsBuilder::new()
@@ -1143,7 +1145,7 @@ fn build_executor_template_config_map(
                 .empty_dir(EmptyDirVolumeSource::default())
                 .build(),
         );
-        pb.add_container(gitsync_container);
+        pb.add_init_container(gitsync_container);
     }
 
     if config.logging.enable_vector_agent {


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/airflow-operator/issues/379. Run git-sync as one-time call in an init container for k8s-mode.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
