### PR TITLE
fix(webserver): raise liveness probe timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use new ldap::AuthenticationClassProvider `endpoint_url()` method ([#366]).
 - Support git-sync `4.2.1` ([#387]).
 - Use a lightweight DAG for the getting started guide to avoid OOM issues ([#401])
+- Raise the default readiness and liveness probe timeouts of the webserver to 120s ([#402])
 
 ### Fixed
 
@@ -37,6 +38,7 @@
 [#381]: https://github.com/stackabletech/airflow-operator/pull/381
 [#387]: https://github.com/stackabletech/airflow-operator/pull/387
 [#401]: https://github.com/stackabletech/airflow-operator/pull/401
+[#402]: https://github.com/stackabletech/airflow-operator/pull/402
 
 ## [23.11.0] - 2023-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Support git-sync `4.2.1` ([#387]).
 - Use a lightweight DAG for the getting started guide to avoid OOM issues ([#401])
 - Raise the default readiness and liveness probe timeouts of the webserver to 120s ([#402])
+  Also raise the memory request of the webserver from 2Gi to 3Gi.
 
 ### Fixed
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -658,7 +658,7 @@ fn default_resources(role: &AirflowRole) -> ResourcesFragment<AirflowStorageConf
                 max: Some(Quantity("2".into())),
             },
             MemoryLimitsFragment {
-                limit: Some(Quantity("2Gi".into())),
+                limit: Some(Quantity("3Gi".into())),
                 runtime_limits: NoRuntimeLimitsFragment {},
             },
         ),

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -871,8 +871,9 @@ fn build_server_rolegroup_statefulset(
                 port: IntOrString::Int(resolved_port.into()),
                 ..TCPSocketAction::default()
             }),
-            initial_delay_seconds: Some(20),
-            period_seconds: Some(5),
+            initial_delay_seconds: Some(60),
+            period_seconds: Some(10),
+            failure_threshold: Some(6),
             ..Probe::default()
         };
         airflow_container.readiness_probe(probe.clone());

--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -13,4 +13,4 @@ releases:
       listener:
         operatorVersion: 0.0.0-dev
       airflow:
-        operatorVersion: 0.0.0-pr402
+        operatorVersion: 0.0.0-dev

--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -13,4 +13,4 @@ releases:
       listener:
         operatorVersion: 0.0.0-dev
       airflow:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 0.0.0-pr402

--- a/tests/templates/kuttl/ldap/03-install-openldap.yaml.j2
+++ b/tests/templates/kuttl/ldap/03-install-openldap.yaml.j2
@@ -38,6 +38,10 @@ commands:
               app.kubernetes.io/name: openldap
           spec:
             serviceAccountName: "ldap-sa"
+            #
+            # The security context below is necessary to avoid the following error on OpenShift:
+            #    /opt/bitnami/scripts/openldap/setup.sh: line 102: /opt/bitnami/openldap/sbin/slappasswd: Operation not permitted
+            #
             securityContext:
               fsGroup: 1000
             containers:

--- a/tests/templates/kuttl/ldap/03-install-openldap.yaml.j2
+++ b/tests/templates/kuttl/ldap/03-install-openldap.yaml.j2
@@ -38,6 +38,8 @@ commands:
               app.kubernetes.io/name: openldap
           spec:
             serviceAccountName: "ldap-sa"
+            securityContext:
+              fsGroup: 1000
             containers:
               - name: openldap
                 image: docker.io/bitnami/openldap:2.5


### PR DESCRIPTION
# Description

The `webserver` pods don't start up in timely manner and are stuck in crash loop.

# Solution

Raise memory request and liveness timeouts.

Tests are successful on OpenShift 4.15:

```
--- PASS: kuttl (918.99s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_airflow-2.8.1_openshift-true_executor-kubernetes (290.13s)
        --- PASS: kuttl/harness/cluster-operation_airflow-latest-2.8.1_openshift-true (317.03s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.8.1_openshift-true_executor-kubernetes (179.60s)
        --- PASS: kuttl/harness/ldap_airflow-latest-2.8.1_ldap-authentication-server-verification-tls_openshift-true_executor-kubernetes (196.86s)
        --- PASS: kuttl/harness/orphaned-resources_airflow-latest-2.8.1_openshift-true (163.28s)
        --- PASS: kuttl/harness/resources_airflow-latest-2.8.1_openshift-true (174.08s)
        --- PASS: kuttl/harness/mount-dags-configmap_airflow-latest-2.8.1_openshift-true_executor-kubernetes (172.05s)
        --- PASS: kuttl/harness/logging_airflow-2.8.1_openshift-true (230.84s)
PASS
```
# OpenShift Notes

**Update**: see comment below. Patched kuttl does the trick.

The `ldap` tests fails with:

```
    logger.go:42: 17:32:39 | ldap_airflow-latest-2.8.1_ldap-authentication-server-verification-tls_openshift-true_executor-kubernetes/3-openldap | Error from server (Forbidden): error when creating "STDIN": statefulsets.apps "openldap" is forbidden: openldap uses an inline volume provided by CSIDriver secrets.stackable.tech and namespace kuttl-test-glad-ewe has a pod security enforce level that is lower than privileged
```

It turns out that OS 4.15 requires  the `openldap` pod (and probably all others too) to run a in a namespace where the "privileged" profile "enforced" as shown below:
```
---
apiVersion: v1
kind: Namespace
metadata:
  labels:
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/warn: privileged
  name: ldap-test
```

This will then succeed:
```
./scripts/run_tests.sh --skip-release --test-suite openshift --test ldap --skip-delete --namespace ldap-test
```

The problem is we currently have no way to set labels to namespaces created by `kuttl`.
