### PR TITLE
fix(manifests): add missing permission for airflow to retrieve temporary pod logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - BREAKING: Fixed various issues in the CRD structure. `clusterConfig.credentialsSecret` is now mandatory ([#353]).
 - Fixed ordering of variables written to the kubernetes executor pod template ([#372]).
 - Fixed git-sync container running with KubernetesExecutor ([#381]).
+- Add missing `pods/log` RBAC permission for airflow. Previously this caused brief error
+  messages in the airflow task logs (`User "system:serviceaccount:default:airflow-serviceaccount" cannot get resource "pods/log" in API group "" in the namespace "default".`) ([#406]).
 
 ### Removed
 
@@ -40,6 +42,7 @@
 [#387]: https://github.com/stackabletech/airflow-operator/pull/387
 [#401]: https://github.com/stackabletech/airflow-operator/pull/401
 [#402]: https://github.com/stackabletech/airflow-operator/pull/402
+[#406]: https://github.com/stackabletech/airflow-operator/pull/406
 
 ## [23.11.0] - 2023-11-24
 

--- a/deploy/helm/airflow-operator/templates/roles.yaml
+++ b/deploy/helm/airflow-operator/templates/roles.yaml
@@ -199,6 +199,12 @@ rules:
       - update
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
       - events.k8s.io
     resources:
       - events


### PR DESCRIPTION
# Description

Add missing permission for airflow to retrieve temporary pod logs.

Before, in Airflow, you would see this while a task is running:

```
sparkapp-dag-spark-pi-monitor-e2ndngqe
*** Attempting to fetch logs from pod sparkapp-dag-spark-pi-monitor-e2ndngqe through kube API
*** Reading from k8s pod logs failed: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': '76bcd5e8-57c5-4585-9e75-17054c661530', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Mon, 18 Mar 2024 09:16:47 GMT', 'Content-Length': '391'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \\"sparkapp-dag-spark-pi-monitor-e2ndngqe\\" is forbidden: User \\"system:serviceaccount:default:airflow-serviceaccount\\" cannot get resource \\"pods/log\\" in API group \\"\\" in the namespace \\"default\\"","reason":"Forbidden","details":{"name":"sparkapp-dag-spark-pi-monitor-e2ndngqe","kind":"pods"},"code":403}\n'
```

> [!NOTE]
> Of course, when using the KubernetesExecutor, the logs disappear once the Pod is stopped, and log export should be enabled:
> 
> ```
> sparkapp-dag-spark-pi-monitor-gezh3lac
> *** Could not read served logs: [Errno -2] Name or service not known
> ```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
