### PR TITLE
fix: revert branch reference to main

### DIFF
--- a/tests/templates/kuttl/mount-dags-gitsync/30-install-airflow-cluster.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/30-install-airflow-cluster.yaml.j2
@@ -35,7 +35,7 @@ spec:
     credentialsSecret: test-airflow-credentials
     dagsGitSync:
       - repo: https://github.com/stackabletech/airflow-operator
-        branch: "fix/dag-plugins" #"main"
+        branch: "main"
         wait: 20
         gitSyncConf:
           # supply some config to check that safe.directory is correctly set


### PR DESCRIPTION
# Description

In the PR-merge for #404 the PR branch was not reverted to `main` and so the integration test tried to git-sync from a non-existent location. This fixes that.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
