### PR TITLE
Add volume mount to the git sync container so that certificates can be mounted

### DIFF
--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1181,6 +1181,7 @@ fn build_gitsync_container(
     name: &str,
     env_vars: Vec<EnvVar>,
 ) -> Result<k8s_openapi::api::core::v1::Container, Error> {
+    let volume_mounts = airflow.volume_mounts();
     let gitsync_container = ContainerBuilder::new(name)
         .context(InvalidContainerNameSnafu)?
         .add_env_vars(env_vars)
@@ -1194,7 +1195,7 @@ fn build_gitsync_container(
         ])
         .args(vec![gitsync.get_args(one_time).join("\n")])
         .add_volume_mount(GIT_CONTENT, GIT_ROOT)
-        .add_volume_mount(airflow.volume_mounts())
+        .add_volume_mount(volume_mounts)
         .resources(
             ResourceRequirementsBuilder::new()
                 .with_cpu_request("100m")

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1195,7 +1195,7 @@ fn build_gitsync_container(
         ])
         .args(vec![gitsync.get_args(one_time).join("\n")])
         .add_volume_mount(GIT_CONTENT, GIT_ROOT)
-        .add_volume_mount(volume_mounts)
+        .add_volume_mounts(airflow.volume_mounts)
         .resources(
             ResourceRequirementsBuilder::new()
                 .with_cpu_request("100m")

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1194,6 +1194,7 @@ fn build_gitsync_container(
         ])
         .args(vec![gitsync.get_args(one_time).join("\n")])
         .add_volume_mount(GIT_CONTENT, GIT_ROOT)
+        .add_volume_mount(airflow.volume_mounts())
         .resources(
             ResourceRequirementsBuilder::new()
                 .with_cpu_request("100m")


### PR DESCRIPTION
# Description

When using kubernetes executors, volume mounts are not mounted to the gitsync initContainer. This causes a problem when a certificate is needed to access a git repository (also when using https:// instead of ssh).
The webserver and the scheduler are able to sync the repositories, to avoid an inconsistent state of the operator, the executors should do to.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
