### PR TITLE
pass volumes/volume-mounts and env-vars through to gitsync containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@
 - Remove requirement of celery configs when using kubernetes executors ([#445]).
 - Processing of corrupted log events fixed; If errors occur, the error
   messages are added to the log event ([#449]).
+- Add volumes/volumeMounts/envOverrides to gitsync containers ([#456]).
 
 [#404]: https://github.com/stackabletech/airflow-operator/pull/404
 [#439]: https://github.com/stackabletech/airflow-operator/pull/439
 [#445]: https://github.com/stackabletech/airflow-operator/pull/445
 [#449]: https://github.com/stackabletech/airflow-operator/pull/449
+[#456]: https://github.com/stackabletech/airflow-operator/pull/456
 
 ## [24.3.0] - 2024-03-20
 

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -14,7 +14,7 @@ use stackable_airflow_crd::{
     GIT_SYNC_NAME, LOG_CONFIG_DIR, OPERATOR_NAME, STACKABLE_LOG_DIR, TEMPLATE_CONFIGMAP_NAME,
     TEMPLATE_LOCATION, TEMPLATE_NAME, TEMPLATE_VOLUME_NAME,
 };
-use stackable_operator::k8s_openapi::api::core::v1::EnvVar;
+use stackable_operator::k8s_openapi::api::core::v1::{EnvVar, VolumeMount};
 use stackable_operator::kube::api::ObjectMeta;
 use stackable_operator::{
     builder::{
@@ -938,6 +938,7 @@ fn build_server_rolegroup_statefulset(
             false,
             &format!("{}-{}", GIT_SYNC_NAME, 1),
             build_gitsync_statefulset_envs(rolegroup_config),
+            airflow.volume_mounts(),
         )?;
 
         pb.add_volume(
@@ -955,6 +956,7 @@ fn build_server_rolegroup_statefulset(
                 true,
                 &format!("{}-{}", GIT_SYNC_NAME, 0),
                 build_gitsync_statefulset_envs(rolegroup_config),
+                airflow.volume_mounts(),
             )?;
             // If the DAG is modularized we may encounter a timing issue whereby the celery worker has started
             // *before* all modules referenced by the DAG have been fetched by gitsync and registered. This
@@ -1122,7 +1124,8 @@ fn build_executor_template_config_map(
             &gitsync,
             true,
             &format!("{}-{}", GIT_SYNC_NAME, 0),
-            build_gitsync_template(&gitsync.credentials_secret),
+            build_gitsync_template(env_overrides),
+            airflow.volume_mounts(),
         )?;
         pb.add_volume(
             VolumeBuilder::new(GIT_CONTENT)
@@ -1180,6 +1183,7 @@ fn build_gitsync_container(
     one_time: bool,
     name: &str,
     env_vars: Vec<EnvVar>,
+    volume_mounts: Vec<VolumeMount>,
 ) -> Result<k8s_openapi::api::core::v1::Container, Error> {
     let gitsync_container = ContainerBuilder::new(name)
         .context(InvalidContainerNameSnafu)?
@@ -1194,6 +1198,7 @@ fn build_gitsync_container(
         ])
         .args(vec![gitsync.get_args(one_time).join("\n")])
         .add_volume_mount(GIT_CONTENT, GIT_ROOT)
+        .add_volume_mounts(volume_mounts)
         .resources(
             ResourceRequirementsBuilder::new()
                 .with_cpu_request("100m")

--- a/tests/templates/kuttl/mount-dags-gitsync/30-install-airflow-cluster.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/30-install-airflow-cluster.yaml.j2
@@ -22,6 +22,14 @@ stringData:
   connections.celeryBrokerUrl: redis://:redis@airflow-redis-master:6379/0
 {% endif %}
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm-gitsync
+data:
+  test.txt: |
+    some test text here
+---
 apiVersion: airflow.stackable.tech/v1alpha1
 kind: AirflowCluster
 metadata:
@@ -43,6 +51,13 @@ spec:
           # supply some config to check that safe.directory is correctly set
           --git-config: http.sslVerify:false
         gitFolder: "tests/templates/kuttl/mount-dags-gitsync/dags"
+    volumeMounts:
+      - name: test-cm-gitsync
+        mountPath: /tmp/test.txt
+    volumes:
+      - name: test-cm-gitsync
+        configMap:
+          name: test-cm-gitsync
   webservers:
     config:
       logging:
@@ -61,11 +76,13 @@ spec:
       default:
         envOverrides:
           AIRFLOW_CONN_KUBERNETES_IN_CLUSTER: "kubernetes://?__extra__=%7B%22extra__kubernetes__in_cluster%22%3A+true%2C+%22extra__kubernetes__kube_config%22%3A+%22%22%2C+%22extra__kubernetes__kube_config_path%22%3A+%22%22%2C+%22extra__kubernetes__namespace%22%3A+%22%22%7D"
+          AIRFLOW_TEST_VAR: "test"
         replicas: 1
 {% elif test_scenario['values']['executor'] == 'kubernetes' %}
   kubernetesExecutors:
     envOverrides:
       AIRFLOW_CONN_KUBERNETES_IN_CLUSTER: "kubernetes://?__extra__=%7B%22extra__kubernetes__in_cluster%22%3A+true%2C+%22extra__kubernetes__kube_config%22%3A+%22%22%2C+%22extra__kubernetes__kube_config_path%22%3A+%22%22%2C+%22extra__kubernetes__namespace%22%3A+%22%22%7D"
+      AIRFLOW_TEST_VAR: "test"
     config:
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}

--- a/tests/templates/kuttl/mount-dags-gitsync/31-assert.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/31-assert.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: metrics
+timeout: 30
+commands:
+
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+  # check that the executor template configmap contains mounts and envs
+  # will expect 4 (2 from from the volume declaration + mounts to two containers, base and gitsync)
+  - script: kubectl -n $NAMESPACE get cm airflow-executor-pod-template -o json | jq -r '.data."airflow_executor_pod_template.yaml"'  | grep "test-cm-gitsync" | wc -l | grep 4
+  # will expect 2 (two containers, base and gitsync)
+  - script: kubectl -n $NAMESPACE get cm airflow-executor-pod-template -o json | jq -r '.data."airflow_executor_pod_template.yaml"'  | grep "AIRFLOW_TEST_VAR" | wc -l | grep 2
+{% else %}
+  # check that the statefulset contains mounts and envs
+  # will expect 6 (2 from from the volume declaration + mounts to 3 containers, base and 2 gitsyncs, plus configmap restarter)
+  - script: kubectl -n $NAMESPACE get sts airflow-worker-default -o json | grep "test-cm-gitsync" | wc -l | grep 6
+  # will expect 3 (two containers, base and gitsync-1, and one initContainer gitsync-0)
+  - script: kubectl -n $NAMESPACE get sts airflow-worker-default -o json | grep "AIRFLOW_TEST_VAR" | wc -l | grep 3
+{% endif %}

--- a/tests/templates/kuttl/mount-dags-gitsync/31-assert.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/31-assert.yaml.j2
@@ -1,8 +1,6 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-metadata:
-  name: metrics
 timeout: 30
 commands:
 


### PR DESCRIPTION
# Description

See https://github.com/orgs/stackabletech/discussions/49.
Also part of https://github.com/stackabletech/issues/issues/548.

This is to enable [SSH-usage](https://github.com/kubernetes/git-sync/blob/master/docs/ssh.md) using volumes/volumeMounts/envOverrides (which should be available anyway): incorporating this into the CRD is not part of this ticket.

CI tests :green_circle:  https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/airflow-operator-it-custom/136/

OKD :green_circle:
```
--- PASS: kuttl (806.00s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_airflow-2.8.1_openshift-true_executor-kubernetes (215.72s)
        --- PASS: kuttl/harness/cluster-operation_airflow-latest-2.8.1_openshift-true (269.89s)
        --- PASS: kuttl/harness/logging_airflow-2.8.1_openshift-true (188.91s)
        --- PASS: kuttl/harness/orphaned-resources_airflow-latest-2.8.1_openshift-true (176.65s)
        --- PASS: kuttl/harness/ldap_airflow-latest-2.8.1_ldap-authentication-server-verification-tls_openshift-true_executor-kubernetes (195.68s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.8.1_openshift-true_executor-kubernetes (223.35s)
        --- PASS: kuttl/harness/mount-dags-configmap_airflow-latest-2.8.1_openshift-true_executor-kubernetes (144.86s)
        --- PASS: kuttl/harness/resources_airflow-latest-2.8.1_openshift-true (127.48s)
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (adapted gitsync test)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Code contains useful logging statements
- [x] (Integration-)Test cases added (adapted gitsync test)
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
