### PR TITLE
chore: Add airflow 2.9.3, deprecate 2.9.2, remove 2.6.x and 2.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for `2.9.3` ([#494]).
+
 ### Changed
 
 - Reduce CRD size from `1.7MB` to `111KB` by accepting arbitrary YAML input instead of the underlying schema for the following fields ([#488]):
@@ -9,6 +13,7 @@
   - `affinity`
   - `volumes`
   - `volumeMounts`
+- Deprecate `2.9.2`, remove `2.6.x` and `2.8.x` ([#494]).
 
 ### Fixed
 
@@ -16,6 +21,7 @@
 
 [#488]: https://github.com/stackabletech/airflow-operator/pull/488
 [#489]: https://github.com/stackabletech/airflow-operator/pull/489
+[#494]: https://github.com/stackabletech/airflow-operator/pull/494
 
 ## [24.7.0] - 2024-07-24
 

--- a/docs/modules/airflow/examples/example-airflow-dags-configmap.yaml
+++ b/docs/modules/airflow/examples/example-airflow-dags-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: airflow
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     loadExamples: false
     exposeConfig: false

--- a/docs/modules/airflow/examples/example-airflow-gitsync.yaml
+++ b/docs/modules/airflow/examples/example-airflow-gitsync.yaml
@@ -5,7 +5,7 @@ metadata:
   name: airflow
 spec:
   image:
-    productVersion: "2.9.2"
+    productVersion: "2.9.3"
   clusterConfig:
     loadExamples: false
     exposeConfig: false

--- a/docs/modules/airflow/examples/example-airflow-incluster.yaml
+++ b/docs/modules/airflow/examples/example-airflow-incluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: airflow
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     loadExamples: false
     exposeConfig: false

--- a/docs/modules/airflow/examples/getting_started/code/airflow.yaml
+++ b/docs/modules/airflow/examples/getting_started/code/airflow.yaml
@@ -5,7 +5,7 @@ metadata:
   name: airflow
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     loadExamples: true
     exposeConfig: false

--- a/docs/modules/airflow/pages/usage-guide/security.adoc
+++ b/docs/modules/airflow/pages/usage-guide/security.adoc
@@ -23,7 +23,7 @@ metadata:
   name: airflow-with-ldap
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     authentication:
       - authenticationClass: ldap    # <1>

--- a/docs/modules/airflow/partials/supported-versions.adoc
+++ b/docs/modules/airflow/partials/supported-versions.adoc
@@ -2,7 +2,5 @@
 // This is a separate file, since it is used by both the direct Airflow-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
-- 2.9.2 (LTS)
-- 2.8.4 (deprecated)
-- 2.8.1 (deprecated)
-- 2.6.3 (deprecated)
+- 2.9.3 (LTS)
+- 2.9.2 (deprecated)

--- a/examples/simple-airflow-cluster-dags-cmap.yaml
+++ b/examples/simple-airflow-cluster-dags-cmap.yaml
@@ -82,7 +82,7 @@ metadata:
   name: airflow-dags-cmap
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     loadExamples: false
     exposeConfig: false

--- a/examples/simple-airflow-cluster-ldap-insecure-tls.yaml
+++ b/examples/simple-airflow-cluster-ldap-insecure-tls.yaml
@@ -148,7 +148,7 @@ metadata:
   name: airflow-insecure-tls
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     loadExamples: true
     exposeConfig: true

--- a/examples/simple-airflow-cluster-ldap.yaml
+++ b/examples/simple-airflow-cluster-ldap.yaml
@@ -146,7 +146,7 @@ metadata:
   name: airflow-with-ldap-server-veri-tls
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     loadExamples: true
     exposeConfig: true

--- a/examples/simple-airflow-cluster.yaml
+++ b/examples/simple-airflow-cluster.yaml
@@ -22,7 +22,7 @@ metadata:
   name: airflow
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     loadExamples: true
     exposeConfig: false

--- a/rust/crd/src/affinity.rs
+++ b/rust/crd/src/affinity.rs
@@ -70,7 +70,7 @@ mod tests {
           name: airflow
         spec:
           image:
-            productVersion: 2.9.2
+            productVersion: 2.9.3
           clusterConfig:
             credentialsSecret: airflow-credentials
           webservers:
@@ -164,7 +164,7 @@ mod tests {
           name: airflow
         spec:
           image:
-            productVersion: 2.9.2
+            productVersion: 2.9.3
           clusterConfig:
             credentialsSecret: airflow-credentials
           webservers:

--- a/rust/crd/src/git_sync.rs
+++ b/rust/crd/src/git_sync.rs
@@ -108,7 +108,7 @@ mod tests {
           name: airflow
         spec:
           image:
-            productVersion: 2.9.2
+            productVersion: 2.9.3
           clusterConfig:
             loadExamples: false
             exposeConfig: false
@@ -154,7 +154,7 @@ mod tests {
           name: airflow
         spec:
           image:
-            productVersion: 2.9.2
+            productVersion: 2.9.3
           clusterConfig:
             loadExamples: false
             exposeConfig: false
@@ -227,7 +227,7 @@ mod tests {
           name: airflow
         spec:
           image:
-            productVersion: 2.9.2
+            productVersion: 2.9.3
           clusterConfig:
             loadExamples: false
             exposeConfig: false

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -779,7 +779,7 @@ mod tests {
           name: airflow
         spec:
           image:
-            productVersion: 2.9.2
+            productVersion: 2.9.3
           clusterConfig:
             loadExamples: true
             exposeConfig: true
@@ -803,7 +803,7 @@ mod tests {
         let resolved_airflow_image: ResolvedProductImage =
             cluster.spec.image.resolve("airflow", "0.0.0-dev");
 
-        assert_eq!("2.9.2", &resolved_airflow_image.product_version);
+        assert_eq!("2.9.3", &resolved_airflow_image.product_version);
 
         assert_eq!("KubernetesExecutor", cluster.spec.executor.to_string());
         assert!(cluster.spec.cluster_config.load_examples);

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1073,7 +1073,7 @@ fn build_executor_template_config_map(
         .context(GracefulShutdownSnafu)?;
 
     // N.B. this "base" name is an airflow requirement and should not be changed!
-    // See https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/kubernetes_executor.html#base-image
+    // See https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/8.4.0/kubernetes_executor.html#base-image
     let mut airflow_container =
         ContainerBuilder::new(&Container::Base.to_string()).context(InvalidContainerNameSnafu)?;
 

--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1073,7 +1073,7 @@ fn build_executor_template_config_map(
         .context(GracefulShutdownSnafu)?;
 
     // N.B. this "base" name is an airflow requirement and should not be changed!
-    // See https://airflow.apache.org/docs/apache-airflow/2.6.1/core-concepts/executor/kubernetes.html#base-image
+    // See https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/kubernetes_executor.html#base-image
     let mut airflow_container =
         ContainerBuilder::new(&Container::Base.to_string()).context(InvalidContainerNameSnafu)?;
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -7,15 +7,13 @@
 dimensions:
   - name: airflow
     values:
-      - 2.6.3
-      - 2.8.1
-      - 2.8.4
       - 2.9.2
+      - 2.9.3
       # To use a custom image, add a comma and the full name after the product version
       # - 2.8.1,docker.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
   - name: airflow-latest
     values:
-      - 2.8.1
+      - 2.9.3
       # To use a custom image, add a comma and the full name after the product version
       # - 2.8.1,docker.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
   - name: ldap-authentication


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/issues/issues/626

```[tasklist]
### Depends on
- [ ] https://github.com/stackabletech/docker-images/pull/809
```

- Add `2.9.3`
- Deprecate `2.9.2`
- Remove `2.6.x` and `2.8.x`
