### PR TITLE
feat: Add Airflow 2.10.2 to tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Allowing arbitrary python code as `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `webserver_config.py` ([#493]).
 - Support for `2.9.3` ([#494]).
+- Experimental Support for `2.10.2` ([#512]).
 
 ### Changed
 

--- a/docs/modules/airflow/partials/supported-versions.adoc
+++ b/docs/modules/airflow/partials/supported-versions.adoc
@@ -2,5 +2,6 @@
 // This is a separate file, since it is used by both the direct Airflow-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
+- 2.10.2 (experimental)
 - 2.9.3 (LTS)
 - 2.9.2 (deprecated)

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -9,11 +9,12 @@ dimensions:
     values:
       - 2.9.2
       - 2.9.3
+      - 2.10.2
       # To use a custom image, add a comma and the full name after the product version
       # - 2.8.1,docker.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
   - name: airflow-latest
     values:
-      - 2.9.3
+      - 2.10.2
       # To use a custom image, add a comma and the full name after the product version
       # - 2.8.1,docker.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
   - name: ldap-authentication


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/847

Add Airflow 2.10.2 to tests and docs (except getting_started).

> [!NOTE]
> @sbernauer and I discussed whether the experimental version should be listed as latest, or even included in the general test run. We decided on adding it, and if it proves problematic, we can remove it again.

# Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
```
