### PR TITLE
ci: Tweak the integration test configuration

### DIFF
--- a/tests/infrastructure.yaml
+++ b/tests/infrastructure.yaml
@@ -1,1 +1,2 @@
-instance-size: medium
+instance-size: large
+nodes: 3


### PR DESCRIPTION
This PR bumps the instance size and node count for integration tests. Compared to integration tests running on Jenkins this uses kind instead of AKS to potentially save money. Testing if this change was effective can only be done once merged.