### PR TITLE
chore: bump postgresql helm chart version in tests

### DIFF
--- a/tests/templates/kuttl/cluster-operation/02-install-postgresql.yaml
+++ b/tests/templates/kuttl/cluster-operation/02-install-postgresql.yaml
@@ -7,5 +7,5 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
     timeout: 600

--- a/tests/templates/kuttl/cluster-operation/02-install-postgresql.yaml
+++ b/tests/templates/kuttl/cluster-operation/02-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
     timeout: 600

--- a/tests/templates/kuttl/ldap/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/ldap/05-install-postgresql.yaml
@@ -7,5 +7,5 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
     timeout: 600

--- a/tests/templates/kuttl/ldap/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/ldap/05-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
     timeout: 600

--- a/tests/templates/kuttl/logging/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/logging/05-install-postgresql.yaml
@@ -7,5 +7,5 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
     timeout: 600

--- a/tests/templates/kuttl/logging/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/logging/05-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
     timeout: 600

--- a/tests/templates/kuttl/mount-dags-configmap/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/mount-dags-configmap/05-install-postgresql.yaml
@@ -7,5 +7,5 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
     timeout: 600

--- a/tests/templates/kuttl/mount-dags-configmap/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/mount-dags-configmap/05-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
     timeout: 600

--- a/tests/templates/kuttl/mount-dags-gitsync/03-install-postgresql.yaml
+++ b/tests/templates/kuttl/mount-dags-gitsync/03-install-postgresql.yaml
@@ -7,5 +7,5 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
     timeout: 600

--- a/tests/templates/kuttl/mount-dags-gitsync/03-install-postgresql.yaml
+++ b/tests/templates/kuttl/mount-dags-gitsync/03-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
     timeout: 600

--- a/tests/templates/kuttl/oidc/10-install-postgresql.yaml
+++ b/tests/templates/kuttl/oidc/10-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       --values helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
       --wait

--- a/tests/templates/kuttl/oidc/10-install-postgresql.yaml
+++ b/tests/templates/kuttl/oidc/10-install-postgresql.yaml
@@ -7,6 +7,6 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       --values helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
       --wait
     timeout: 600

--- a/tests/templates/kuttl/orphaned-resources/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/orphaned-resources/05-install-postgresql.yaml
@@ -7,5 +7,5 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
     timeout: 600

--- a/tests/templates/kuttl/orphaned-resources/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/orphaned-resources/05-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
     timeout: 600

--- a/tests/templates/kuttl/overrides/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/overrides/05-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
       --wait

--- a/tests/templates/kuttl/overrides/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/overrides/05-install-postgresql.yaml
@@ -7,6 +7,6 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
       --wait
     timeout: 600

--- a/tests/templates/kuttl/resources/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/resources/05-install-postgresql.yaml
@@ -7,5 +7,5 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
     timeout: 600

--- a/tests/templates/kuttl/resources/05-install-postgresql.yaml
+++ b/tests/templates/kuttl/resources/05-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
     timeout: 600

--- a/tests/templates/kuttl/smoke/10-install-postgresql.yaml
+++ b/tests/templates/kuttl/smoke/10-install-postgresql.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-postgresql
       --namespace $NAMESPACE
-      --version 12.5.6
+      --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
       --repo https://charts.bitnami.com/bitnami postgresql
       --wait

--- a/tests/templates/kuttl/smoke/10-install-postgresql.yaml
+++ b/tests/templates/kuttl/smoke/10-install-postgresql.yaml
@@ -7,6 +7,6 @@ commands:
       --namespace $NAMESPACE
       --version 16.4.2
       -f helm-bitnami-postgresql-values.yaml
-      --repo https://charts.bitnami.com/bitnami postgresql
+      oci://registry-1.docker.io/bitnamicharts/postgresql
       --wait
     timeout: 600


### PR DESCRIPTION
# Description

Bump postgresql helm chart version to most recent one.
Installation of version 12.5.6 seems to fail due to the chart being missing or rate limits being enforced by bitnami, see https://testing.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/airflow-operator-it-custom/15/artifact/target/test-output.log

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
