### PR TITLE
chore: bump opa to 1.0.1

### DIFF
--- a/tests/templates/kuttl/opa/31-opa-rules.yaml
+++ b/tests/templates/kuttl/opa/31-opa-rules.yaml
@@ -9,8 +9,6 @@ data:
   airflow.rego: |
     package airflow
 
-    import rego.v1
-
     default is_authorized_configuration := false
     default is_authorized_connection := false
     default is_authorized_dag := false

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -19,7 +19,7 @@ dimensions:
       # - 2.8.1,oci.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
   - name: opa-latest
     values:
-      - 0.67.1
+      - 1.0.1
   - name: ldap-authentication
     values:
       - no-tls


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/998

Tests:

```
--- PASS: kuttl (222.93s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/opa_airflow-2.10.2_opa-latest-1.0.1_openshift-false (222.91s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
