### PR TITLE
chore(docs): Update getting-started script pre-25.3.0

### DIFF
--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh
@@ -22,7 +22,7 @@ echo "Adding bitnami Helm Chart repository and dependencies (Postgresql and Redi
 helm repo add bitnami https://charts.bitnami.com/bitnami
 # end::helm-add-bitnami-repo[]
 # tag::helm-add-bitnami-pgs[]
-helm install --wait airflow-postgresql bitnami/postgresql --version 12.1.5 \
+helm install --wait airflow-postgresql bitnami/postgresql --version 16.5.0 \
     --set auth.username=airflow \
     --set auth.password=airflow \
     --set auth.database=airflow
@@ -30,7 +30,7 @@ helm install --wait airflow-postgresql bitnami/postgresql --version 12.1.5 \
 # tag::helm-add-bitnami-redis[]
 helm install --wait airflow-redis bitnami/redis \
     --set auth.password=redis \
-    --version 17.3.7 \
+    --version 20.11.3 \
     --set replica.replicaCount=1
 # end::helm-add-bitnami-redis[]
 

--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh
@@ -27,7 +27,7 @@ helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgre
   --wait
 # end::helm-add-bitnami-pgs[]
 # tag::helm-add-bitnami-redis[]
-helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/redis \
+helm install airflow-redis oci://registry-1.docker.io/bitnamicharts/redis \
   --version 20.11.3 \
   --set replica.replicaCount=1 \
   --set auth.password=redis \

--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh
@@ -18,20 +18,20 @@ then
 fi
 
 echo "Adding bitnami Helm Chart repository and dependencies (Postgresql and Redis)"
-# tag::helm-add-bitnami-repo[]
-helm repo add bitnami https://charts.bitnami.com/bitnami
-# end::helm-add-bitnami-repo[]
 # tag::helm-add-bitnami-pgs[]
-helm install --wait airflow-postgresql bitnami/postgresql --version 16.5.0 \
-    --set auth.username=airflow \
-    --set auth.password=airflow \
-    --set auth.database=airflow
+helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+  --version 16.5.0 \
+  --set auth.database=airflow \
+  --set auth.username=airflow \
+  --set auth.password=airflow \
+  --wait
 # end::helm-add-bitnami-pgs[]
 # tag::helm-add-bitnami-redis[]
-helm install --wait airflow-redis bitnami/redis \
-    --set auth.password=redis \
-    --version 20.11.3 \
-    --set replica.replicaCount=1
+helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/redis \
+  --version 20.11.3 \
+  --set replica.replicaCount=1 \
+  --set auth.password=redis \
+  --wait
 # end::helm-add-bitnami-redis[]
 
 case "$1" in

--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
@@ -27,7 +27,7 @@ helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgre
   --wait
 # end::helm-add-bitnami-pgs[]
 # tag::helm-add-bitnami-redis[]
-helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/redis \
+helm install airflow-redis oci://registry-1.docker.io/bitnamicharts/redis \
   --version {{ versions.redis }} \
   --set replica.replicaCount=1 \
   --set auth.password=redis \

--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
@@ -18,20 +18,20 @@ then
 fi
 
 echo "Adding bitnami Helm Chart repository and dependencies (Postgresql and Redis)"
-# tag::helm-add-bitnami-repo[]
-helm repo add bitnami https://charts.bitnami.com/bitnami
-# end::helm-add-bitnami-repo[]
 # tag::helm-add-bitnami-pgs[]
-helm install --wait airflow-postgresql bitnami/postgresql --version {{ versions.postgresql }} \
-    --set auth.username=airflow \
-    --set auth.password=airflow \
-    --set auth.database=airflow
+helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+  --version {{ versions.postgresql }} \
+  --set auth.database=airflow \
+  --set auth.username=airflow \
+  --set auth.password=airflow \
+  --wait
 # end::helm-add-bitnami-pgs[]
 # tag::helm-add-bitnami-redis[]
-helm install --wait airflow-redis bitnami/redis \
-    --set auth.password=redis \
-    --version {{ versions.redis }} \
-    --set replica.replicaCount=1
+helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/redis \
+  --version {{ versions.redis }} \
+  --set replica.replicaCount=1 \
+  --set auth.password=redis \
+  --wait
 # end::helm-add-bitnami-redis[]
 
 case "$1" in

--- a/docs/modules/airflow/pages/getting_started/installation.adoc
+++ b/docs/modules/airflow/pages/getting_started/installation.adoc
@@ -13,10 +13,6 @@ Note that specific versions are declared:
 
 [source,bash]
 ----
-include::example$getting_started/code/getting_started.sh[tag=helm-add-bitnami-repo]
-----
-[source,bash]
-----
 include::example$getting_started/code/getting_started.sh[tag=helm-add-bitnami-pgs]
 ----
 [source,bash]

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -7,5 +7,5 @@ versions:
   secret: 0.0.0-dev
   listener: 0.0.0-dev
   airflow: 0.0.0-dev
-  postgresql: 12.1.5
-  redis: 17.3.7
+  postgresql: 16.5.0
+  redis: 20.11.3


### PR DESCRIPTION
# Check and Update Getting Started Script

Part of <https://github.com/stackabletech/issues/issues/697>

This PR bumps the following charts:

- `postgresql` to 16.5.0
- `redis` to 20.11.3

```shell
# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm
```
