### PR TITLE
feat!: Use `Tracing::pre_configured` from stackable-telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Changed
 
-- Replace stackable-operator `initialize_logging` with stackable-telemetry `Tracing` ([#601]).
-  - BREAKING: The file log directory was set by `AIRFLOW_OPERATOR_LOG_DIRECTORY`, and is now set by `ROLLING_LOGS`
-    (or via `--rolling-logs <DIRECTORY>`).
+- BREAKING: Replace stackable-operator `initialize_logging` with stackable-telemetry `Tracing` ([#601], [#608]).
+  - The console log level was set by `AIRFLOW_OPERATOR_LOG`, and is now set by `CONSOLE_LOG`.
+  - The file log level was set by `AIRFLOW_OPERATOR_LOG`, and is now set by `FILE_LOG`.
+  - The file log directory was set by `AIRFLOW_OPERATOR_LOG_DIRECTORY`, and is now set
+    by `ROLLING_LOGS_DIR` (or via `--rolling-logs <DIRECTORY>`).
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#600]).
@@ -19,6 +21,7 @@
 [#600]: https://github.com/stackabletech/airflow-operator/pull/600
 [#601]: https://github.com/stackabletech/airflow-operator/pull/601
 [#607]: https://github.com/stackabletech/airflow-operator/pull/607
+[#608]: https://github.com/stackabletech/airflow-operator/pull/608
 
 ## [25.3.0] - 2025-03-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-versioned-0.7.1#6c4b022dcdaec09a0c0ecb420a41bb180d4edbf8"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "darling",
  "regex",
@@ -2659,8 +2659,6 @@ dependencies = [
  "serde_yaml",
  "snafu 0.8.5",
  "stackable-operator",
- "stackable-telemetry",
- "stackable-versioned",
  "strum",
  "tokio",
  "tracing",
@@ -2668,8 +2666,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.90.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.90.0#ea063b4595caa20c82d37c595487c76476c9ab10"
+version = "0.91.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "chrono",
  "clap",
@@ -2693,6 +2691,8 @@ dependencies = [
  "snafu 0.8.5",
  "stackable-operator-derive",
  "stackable-shared",
+ "stackable-telemetry",
+ "stackable-versioned",
  "strum",
  "tokio",
  "tracing",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.90.0#ea063b4595caa20c82d37c595487c76476c9ab10"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.90.0#ea063b4595caa20c82d37c595487c76476c9ab10"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "kube",
  "semver",
@@ -2726,10 +2726,11 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.4.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-telemetry-0.4.0#52bdee5749e217005025d07f33c7020931c31d91"
+version = "0.5.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "axum 0.8.3",
+ "clap",
  "futures-util",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -2737,6 +2738,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pin-project",
  "snafu 0.8.5",
+ "strum",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -2748,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.7.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-versioned-0.7.1#6c4b022dcdaec09a0c0ecb420a41bb180d4edbf8"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "stackable-versioned-macros",
 ]
@@ -2756,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.7.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-versioned-0.7.1#6c4b022dcdaec09a0c0ecb420a41bb180d4edbf8"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "convert_case",
  "darling",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -948,9 +948,9 @@ rec {
       };
       "backon" = rec {
         crateName = "backon";
-        version = "1.4.1";
+        version = "1.5.0";
         edition = "2021";
-        sha256 = "1drv0gvhjs3g0q88f1mknqjdyhh6qg8pvb9nkfasba011ibr23cp";
+        sha256 = "15k4p6xyxi4lkiyw5yxrmcws3wwnwjacgcqqmd2dvfldnyqm02zx";
         dependencies = [
           {
             name = "fastrand";
@@ -1697,9 +1697,9 @@ rec {
       };
       "crossbeam-channel" = rec {
         crateName = "crossbeam-channel";
-        version = "0.5.14";
+        version = "0.5.15";
         edition = "2021";
-        sha256 = "0wa41qybq5w8s70anb472myh4fid4aw6v65vws6wn528w9l6vfh6";
+        sha256 = "1cicd9ins0fkpfgvz9vhz3m9rpkh6n8d3437c3wnfsdkd3wgif42";
         libName = "crossbeam_channel";
         dependencies = [
           {
@@ -4667,12 +4667,12 @@ rec {
       "k8s-version" = rec {
         crateName = "k8s-version";
         version = "0.1.2";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6c4b022dcdaec09a0c0ecb420a41bb180d4edbf8";
-          sha256 = "16klfwx3kz3ys7afwjicfj8msws9a718izx09jspwwpff3rl6wsi";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "k8s_version";
         authors = [
@@ -5516,9 +5516,9 @@ rec {
       };
       "miniz_oxide" = rec {
         crateName = "miniz_oxide";
-        version = "0.8.7";
+        version = "0.8.8";
         edition = "2021";
-        sha256 = "0c4lj692adnzw0h9j8l24d7imds3icpgdkk3b03zlhxf90zcww7z";
+        sha256 = "0al9iy33flfgxawj789w2c8xxwg1n2r5vv6m6p5hl2fvd2vlgriv";
         authors = [
           "Frommi <daniil.liferenko@gmail.com>"
           "oyvindln <oyvindln@users.noreply.github.com>"
@@ -8646,15 +8646,7 @@ rec {
           {
             name = "stackable-operator";
             packageId = "stackable-operator";
-          }
-          {
-            name = "stackable-telemetry";
-            packageId = "stackable-telemetry";
-          }
-          {
-            name = "stackable-versioned";
-            packageId = "stackable-versioned";
-            features = [ "k8s" ];
+            features = [ "telemetry" "versioned" ];
           }
           {
             name = "strum";
@@ -8692,13 +8684,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.90.0";
+        version = "0.91.1";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "ea063b4595caa20c82d37c595487c76476c9ab10";
-          sha256 = "0fclvpxhchykqd7bl8hscr4v06mbs2v5vjp0xv27nvqr94j63xs2";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "stackable_operator";
         authors = [
@@ -8804,6 +8796,16 @@ rec {
             packageId = "stackable-shared";
           }
           {
+            name = "stackable-telemetry";
+            packageId = "stackable-telemetry";
+            features = [ "clap" ];
+          }
+          {
+            name = "stackable-versioned";
+            packageId = "stackable-versioned";
+            features = [ "k8s" ];
+          }
+          {
             name = "strum";
             packageId = "strum";
             features = [ "derive" ];
@@ -8833,8 +8835,11 @@ rec {
           }
         ];
         features = {
+          "default" = [ "telemetry" "versioned" ];
+          "full" = [ "time" "telemetry" "versioned" ];
           "time" = [ "dep:time" ];
         };
+        resolvedDefaultFeatures = [ "default" "telemetry" "versioned" ];
       };
       "stackable-operator-derive" = rec {
         crateName = "stackable-operator-derive";
@@ -8843,8 +8848,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "ea063b4595caa20c82d37c595487c76476c9ab10";
-          sha256 = "0fclvpxhchykqd7bl8hscr4v06mbs2v5vjp0xv27nvqr94j63xs2";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -8878,8 +8883,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "ea063b4595caa20c82d37c595487c76476c9ab10";
-          sha256 = "0fclvpxhchykqd7bl8hscr4v06mbs2v5vjp0xv27nvqr94j63xs2";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "stackable_shared";
         authors = [
@@ -8914,13 +8919,13 @@ rec {
       };
       "stackable-telemetry" = rec {
         crateName = "stackable-telemetry";
-        version = "0.4.0";
+        version = "0.5.0";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "52bdee5749e217005025d07f33c7020931c31d91";
-          sha256 = "0hcm64fb2ngyalq8rci5lrr881prg023pq9cd1sfr79iynbr6a26";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -8930,6 +8935,12 @@ rec {
           {
             name = "axum";
             packageId = "axum 0.8.3";
+          }
+          {
+            name = "clap";
+            packageId = "clap";
+            optional = true;
+            features = [ "derive" "cargo" "env" ];
           }
           {
             name = "futures-util";
@@ -8961,6 +8972,11 @@ rec {
           {
             name = "snafu";
             packageId = "snafu 0.8.5";
+          }
+          {
+            name = "strum";
+            packageId = "strum";
+            features = [ "derive" ];
           }
           {
             name = "tokio";
@@ -9001,17 +9017,20 @@ rec {
             packageId = "tracing-opentelemetry";
           }
         ];
-
+        features = {
+          "clap" = [ "dep:clap" ];
+        };
+        resolvedDefaultFeatures = [ "clap" ];
       };
       "stackable-versioned" = rec {
         crateName = "stackable-versioned";
         version = "0.7.1";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6c4b022dcdaec09a0c0ecb420a41bb180d4edbf8";
-          sha256 = "16klfwx3kz3ys7afwjicfj8msws9a718izx09jspwwpff3rl6wsi";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "stackable_versioned";
         authors = [
@@ -9032,12 +9051,12 @@ rec {
       "stackable-versioned-macros" = rec {
         crateName = "stackable-versioned-macros";
         version = "0.7.1";
-        edition = "2021";
+        edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6c4b022dcdaec09a0c0ecb420a41bb180d4edbf8";
-          sha256 = "16klfwx3kz3ys7afwjicfj8msws9a718izx09jspwwpff3rl6wsi";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -12894,10 +12913,10 @@ rec {
       };
       "xml-rs" = rec {
         crateName = "xml-rs";
-        version = "0.8.25";
+        version = "0.8.26";
         edition = "2021";
         crateBin = [];
-        sha256 = "1i73ajf6scni5bi1a51r19xykgrambdx5fkks0fyg5jqqbml1ff5";
+        sha256 = "1nkbzksai36pvx3ag1fn9b5cffwb1ldl66aglwcip42nkdnyfb56";
         libName = "xml";
         authors = [
           "Vladimir Matveev <vmatveev@citrine.cc>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ repository = "https://github.com/stackabletech/airflow-operator"
 
 [workspace.dependencies]
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.7.0" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.90.0" }
-stackable-telemetry = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-telemetry-0.4.0" }
-stackable-versioned = { git = "https://github.com/stackabletech/operator-rs.git", features = ["k8s"], tag = "stackable-versioned-0.7.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", features = ["telemetry", "versioned"], tag = "stackable-operator-0.91.1" }
 
 anyhow = "1.0"
 built = { version = "0.7", features = ["chrono", "git2"] }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,10 +1,10 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.90.0#stackable-operator-derive@0.3.1": "0fclvpxhchykqd7bl8hscr4v06mbs2v5vjp0xv27nvqr94j63xs2",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.90.0#stackable-operator@0.90.0": "0fclvpxhchykqd7bl8hscr4v06mbs2v5vjp0xv27nvqr94j63xs2",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.90.0#stackable-shared@0.0.1": "0fclvpxhchykqd7bl8hscr4v06mbs2v5vjp0xv27nvqr94j63xs2",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-telemetry-0.4.0#stackable-telemetry@0.4.0": "0hcm64fb2ngyalq8rci5lrr881prg023pq9cd1sfr79iynbr6a26",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-versioned-0.7.1#k8s-version@0.1.2": "16klfwx3kz3ys7afwjicfj8msws9a718izx09jspwwpff3rl6wsi",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-versioned-0.7.1#stackable-versioned-macros@0.7.1": "16klfwx3kz3ys7afwjicfj8msws9a718izx09jspwwpff3rl6wsi",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-versioned-0.7.1#stackable-versioned@0.7.1": "16klfwx3kz3ys7afwjicfj8msws9a718izx09jspwwpff3rl6wsi",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#k8s-version@0.1.2": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-operator-derive@0.3.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-operator@0.91.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-shared@0.0.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-telemetry@0.5.0": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-versioned-macros@0.7.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-versioned@0.7.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -11,8 +11,6 @@ publish = false
 [dependencies]
 product-config.workspace = true
 stackable-operator.workspace = true
-stackable-telemetry.workspace = true
-stackable-versioned.workspace = true
 
 anyhow.workspace = true
 clap.workspace = true

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -40,8 +40,8 @@ use stackable_operator::{
     status::condition::{ClusterCondition, HasStatusCondition},
     time::Duration,
     utils::{COMMON_BASH_TRAP_FUNCTIONS, crds::raw_object_list_schema},
+    versioned::versioned,
 };
-use stackable_versioned::versioned;
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 
 use crate::crd::{

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -22,12 +22,8 @@ use stackable_operator::{
     },
     logging::controller::report_controller_reconciled,
     shared::yaml::SerializeOptions,
-    telemetry::{
-        Tracing,
-        tracing::{RollingPeriod, settings::Settings},
-    },
+    telemetry::Tracing,
 };
-use tracing::level_filters::LevelFilter;
 
 use crate::{
     airflow_controller::AIRFLOW_FULL_CONTROLLER_NAME,
@@ -72,43 +68,12 @@ async fn main() -> anyhow::Result<()> {
             telemetry_arguments,
             cluster_info_opts,
         }) => {
-            let _tracing_guard = Tracing::builder()
-                // TODO (@Techassi): This should be a constant
-                .service_name("airflow-operator")
-                .with_console_output((
-                    ENV_VAR_CONSOLE_LOG,
-                    LevelFilter::INFO,
-                    !telemetry_arguments.no_console_output,
-                ))
-                // note, before, log dir was set via an env: `AIRFLOW_OPERATOR_LOG_DIRECTORY`.
-                // See: https://github.com/stackabletech/operator-rs/blob/f035997fca85a54238c8de895389cc50b4d421e2/crates/stackable-operator/src/logging/mod.rs#L40
-                // Now it will be `ROLLING_LOGS` (or via `--rolling-logs <DIRECTORY>`)
-                .with_file_output(telemetry_arguments.rolling_logs.map(|log_directory| {
-                    let rotation_period = telemetry_arguments
-                        .rolling_logs_period
-                        .unwrap_or(RollingPeriod::Hourly)
-                        .clone();
-
-                    Settings::builder()
-                        // TODO (@Techassi): Change to CONSOLE_LOG or FILE_LOG, create constant
-                        .with_environment_variable(ENV_VAR_CONSOLE_LOG)
-                        .with_default_level(LevelFilter::INFO)
-                        .file_log_settings_builder(log_directory, "tracing-rs.json")
-                        .with_rotation_period(rotation_period)
-                        .build()
-                }))
-                .with_otlp_log_exporter((
-                    "OTLP_LOG",
-                    LevelFilter::DEBUG,
-                    telemetry_arguments.otlp_logs,
-                ))
-                .with_otlp_trace_exporter((
-                    "OTLP_TRACE",
-                    LevelFilter::DEBUG,
-                    telemetry_arguments.otlp_traces,
-                ))
-                .build()
-                .init()?;
+            // NOTE (@NickLarsenNZ): Before stackable-telemetry was used:
+            // - The console log level was set by `AIRFLOW_OPERATOR_LOG`, and is now `CONSOLE_LOG` (when using Tracing::pre_configured).
+            // - The file log level was set by `AIRFLOW_OPERATOR_LOG`, and is now set via `FILE_LOG` (when using Tracing::pre_configured).
+            // - The file log directory was set by `AIRFLOW_OPERATOR_LOG_DIRECTORY`, and is now set by `ROLLING_LOGS_DIR` (or via `--rolling-logs <DIRECTORY>`).
+            let _tracing_guard =
+                Tracing::pre_configured(built_info::PKG_NAME, telemetry_arguments).init()?;
 
             tracing::info!(
                 built_info.pkg_version = built_info::PKG_VERSION,

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -43,9 +43,6 @@ mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-// TODO (@NickLarsenNZ): Change the variable to `CONSOLE_LOG`
-pub const ENV_VAR_CONSOLE_LOG: &str = "AIRFLOW_OPERATOR_LOG";
-
 #[derive(Parser)]
 #[clap(about, author)]
 struct Opts {

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -1,10 +1,10 @@
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use clap::Parser;
 use futures::StreamExt;
 use stackable_operator::{
     YamlSchema,
-    cli::{Command, ProductOperatorRun, RollingPeriod},
+    cli::{Command, ProductOperatorRun},
     commons::authentication::AuthenticationClass,
     k8s_openapi::api::{
         apps::v1::StatefulSet,
@@ -22,8 +22,11 @@ use stackable_operator::{
     },
     logging::controller::report_controller_reconciled,
     shared::yaml::SerializeOptions,
+    telemetry::{
+        Tracing,
+        tracing::{RollingPeriod, settings::Settings},
+    },
 };
-use stackable_telemetry::{Tracing, tracing::settings::Settings};
 use tracing::level_filters::LevelFilter;
 
 use crate::{
@@ -84,7 +87,6 @@ async fn main() -> anyhow::Result<()> {
                     let rotation_period = telemetry_arguments
                         .rolling_logs_period
                         .unwrap_or(RollingPeriod::Hourly)
-                        .deref()
                         .clone();
 
                     Settings::builder()


### PR DESCRIPTION
**Use `Tracing::pre_configured` from stackable-telemetry**

Part of https://github.com/stackabletech/issues/issues/639.

Breaking changes:

#### operator-binary

- The console log level was set by `AIRFLOW_OPERATOR_LOG`, and is now set by `CONSOLE_LOG`.
- The file log level was set by `AIRFLOW_OPERATOR_LOG`, and is now set by `FILE_LOG`.
- The file log directory was previously changed to `ROLLING_LOGS`, but has been updated to `ROLLING_LOGS_DIR`.

### Testing

```
--- PASS: kuttl (869.92s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_airflow-2.10.4_openshift-false_executor-celery (474.70s)
        --- PASS: kuttl/harness/logging_airflow-2.10.4_openshift-false_executor-kubernetes (395.21s)
PASS
```