### PR TITLE
fix: Use correct service for sts

### DIFF
--- a/rust/operator-binary/src/airflow_controller.rs
+++ b/rust/operator-binary/src/airflow_controller.rs
@@ -1161,7 +1161,7 @@ fn build_server_rolegroup_statefulset(
             match_labels: Some(statefulset_match_labels.into()),
             ..LabelSelector::default()
         },
-        service_name: rolegroup_ref.object_name(),
+        service_name: format!("{name}-metrics", name = rolegroup_ref.object_name()),
         template: pod_template,
         volume_claim_templates: pvcs,
         ..StatefulSetSpec::default()


### PR DESCRIPTION
## Description

The StatefulSet should use the headless service and not the group listener service. If the headless service is not used, the logs cannot be retrieved from within the airflow UI:

The upper part of the screenshot shows the listener service being used, and the lower part the (correct) headless service:

![image (11)](https://github.com/user-attachments/assets/9a02e877-61db-4cbe-8b14-7fc08fc658ec)


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
