### PR TITLE
Fix: proper assignment of Boolean "propagate"

### DIFF
--- a/rust/operator-binary/src/product_logging.rs
+++ b/rust/operator-binary/src/product_logging.rs
@@ -113,7 +113,7 @@ for logger_name, logger_config in LOGGING_CONFIG['loggers'].items():
     # Do not change the setting of the airflow.task logger because
     # otherwise DAGs cannot be loaded anymore.
     if logger_name != 'airflow.task':
-        logger_config['propagate'] == True
+        logger_config['propagate'] = True
 
 LOGGING_CONFIG.setdefault('formatters', {{}})
 LOGGING_CONFIG['formatters']['json'] = {{


### PR DESCRIPTION
## Description

Fix as outcome of https://github.com/stackabletech/airflow-operator/issues/646

This change does not require a changelog entry because the field `propagate` is already set to `True` by default since Airflow 2.4.2 (https://github.com/apache/airflow/blob/2.4.2/airflow/config_templates/airflow_local_settings.py#L120-L137) and setting it explicitly does not change the behavior of the product.