### PR TITLE
Fix: airflow.task log level default to INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Use `--console-log-format` (or `CONSOLE_LOG_FORMAT`) to set the format to `plain` (default) or `json`.
 - Add support for airflow `2.10.5` ([#625]).
 - Add experimental support for airflow `3.0.1` ([#630]).
+- "airflow.task" logger defaults to log level 'INFO' instead of 'NOTSET' ([#649]).
 
 ### Changed
 
@@ -50,6 +51,7 @@
 [#630]: https://github.com/stackabletech/airflow-operator/pull/630
 [#636]: https://github.com/stackabletech/airflow-operator/pull/636
 [#645]: https://github.com/stackabletech/airflow-operator/pull/645
+[#649]: https://github.com/stackabletech/airflow-operator/pull/649
 
 ## [25.3.0] - 2025-03-21
 

--- a/docs/modules/airflow/pages/usage-guide/logging.adoc
+++ b/docs/modules/airflow/pages/usage-guide/logging.adoc
@@ -3,6 +3,8 @@
 
 The logs can be forwarded to a Vector log aggregator by providing a discovery ConfigMap for the aggregator and by enabling the log agent:
 
+NOTE: airflow.task loglevel is set to `INFO` by default.
+
 [source,yaml]
 ----
 spec:

--- a/docs/modules/airflow/pages/usage-guide/logging.adoc
+++ b/docs/modules/airflow/pages/usage-guide/logging.adoc
@@ -3,7 +3,7 @@
 
 The logs can be forwarded to a Vector log aggregator by providing a discovery ConfigMap for the aggregator and by enabling the log agent:
 
-NOTE: airflow.task loglevel is set to `INFO` by default.
+NOTE: airflow.task log level is set to `INFO` by default.
 
 [source,yaml]
 ----

--- a/docs/modules/airflow/pages/usage-guide/logging.adoc
+++ b/docs/modules/airflow/pages/usage-guide/logging.adoc
@@ -28,6 +28,8 @@ spec:
             loggers:
               "airflow.processor":
                 level: INFO
+              "airflow.task":
+                level: DEBUG
   schedulers:
     config:
       logging:

--- a/rust/operator-binary/src/product_logging.rs
+++ b/rust/operator-binary/src/product_logging.rs
@@ -114,6 +114,9 @@ for logger_name, logger_config in LOGGING_CONFIG['loggers'].items():
     # otherwise DAGs cannot be loaded anymore.
     if logger_name != 'airflow.task':
         logger_config['propagate'] = True
+    # Adopting to airflows logging standards
+    if logger_name == 'airflow.task':
+        logger_config['level'] = logging.INFO
 
 LOGGING_CONFIG.setdefault('formatters', {{}})
 LOGGING_CONFIG['formatters']['json'] = {{

--- a/rust/operator-binary/src/product_logging.rs
+++ b/rust/operator-binary/src/product_logging.rs
@@ -114,6 +114,11 @@ for logger_name, logger_config in LOGGING_CONFIG['loggers'].items():
     # otherwise DAGs cannot be loaded anymore.
     if logger_name != 'airflow.task':
         logger_config['propagate'] = True
+    # The default behavior of airflow is to enforce log level 'INFO' on tasks. (https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level)
+    # TODO: Make task handler log level configurable through CRDs with default 'INFO'.
+    # e.g. LOGGING_CONFIG['handlers']['task']['level'] = {{task_log_level}}
+    if 'task' in logger_config['handlers']:
+        logger_config['level'] = logging.INFO
 
 LOGGING_CONFIG.setdefault('formatters', {{}})
 LOGGING_CONFIG['formatters']['json'] = {{
@@ -132,10 +137,6 @@ LOGGING_CONFIG['handlers']['file'] = {{
     'maxBytes': 1048576,
     'backupCount': 1,
 }}
-
-# The default behavior of airflow is to enforce log level 'INFO' on tasks. (https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level)
-# TODO: Make task handler log level configurable through CRDs with default 'INFO'.
-LOGGING_CONFIG['handlers']['task']['level'] = logging.INFO
 
 LOGGING_CONFIG['root'] = {{
     'level': {root_log_level},

--- a/rust/operator-binary/src/product_logging.rs
+++ b/rust/operator-binary/src/product_logging.rs
@@ -114,9 +114,6 @@ for logger_name, logger_config in LOGGING_CONFIG['loggers'].items():
     # otherwise DAGs cannot be loaded anymore.
     if logger_name != 'airflow.task':
         logger_config['propagate'] = True
-    # Adopting to airflows logging standards
-    if logger_name == 'airflow.task':
-        logger_config['level'] = logging.INFO
 
 LOGGING_CONFIG.setdefault('formatters', {{}})
 LOGGING_CONFIG['formatters']['json'] = {{
@@ -135,6 +132,10 @@ LOGGING_CONFIG['handlers']['file'] = {{
     'maxBytes': 1048576,
     'backupCount': 1,
 }}
+
+# The default behavior of airflow is to enforce log level 'INFO' on tasks. (https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level)
+# TODO: Make task handler log level configurable through CRDs with default 'INFO'.
+LOGGING_CONFIG['handlers']['task']['level'] = logging.INFO
 
 LOGGING_CONFIG['root'] = {{
     'level': {root_log_level},

--- a/rust/operator-binary/src/product_logging.rs
+++ b/rust/operator-binary/src/product_logging.rs
@@ -117,7 +117,7 @@ for logger_name, logger_config in LOGGING_CONFIG['loggers'].items():
     # The default behavior of airflow is to enforce log level 'INFO' on tasks. (https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level)
     # TODO: Make task handler log level configurable through CRDs with default 'INFO'.
     # e.g. LOGGING_CONFIG['handlers']['task']['level'] = {{task_log_level}}
-    if 'task' in logger_config['handlers']:
+    if 'handlers' in logger_config and 'task' in logger_config['handlers']:
         logger_config['level'] = logging.INFO
 
 LOGGING_CONFIG.setdefault('formatters', {{}})


### PR DESCRIPTION
## Description

As an outcome of [#646](https://github.com/stackabletech/airflow-operator/issues/646) I've updated:

- Log level of airflow.task defaults to `INFO`
- Update documentation

### Author

- [x] Integration tests passed (for non trivial changes)
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
