### PR TITLE
 Listener: Use headless and metrics service

### DIFF
--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -37,6 +37,7 @@ mod crd;
 mod env_vars;
 mod operations;
 mod product_logging;
+mod service;
 mod util;
 
 mod built_info {

--- a/rust/operator-binary/src/service.rs
+++ b/rust/operator-binary/src/service.rs
@@ -1,0 +1,151 @@
+use std::collections::BTreeMap;
+
+use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    builder::meta::ObjectMetaBuilder,
+    k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec},
+    kvp::{Label, ObjectLabels},
+    role_utils::RoleGroupRef,
+};
+
+use crate::crd::{
+    AirflowRole, HTTP_PORT, HTTP_PORT_NAME, METRICS_PORT, METRICS_PORT_NAME, v1alpha1,
+};
+
+pub const METRICS_SERVICE_SUFFIX: &str = "metrics";
+pub const HEADLESS_SERVICE_SUFFIX: &str = "headless";
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("object is missing metadata to build owner reference"))]
+    ObjectMissingMetadataForOwnerRef {
+        source: stackable_operator::builder::meta::Error,
+    },
+
+    #[snafu(display("failed to build Metadata"))]
+    MetadataBuild {
+        source: stackable_operator::builder::meta::Error,
+    },
+
+    #[snafu(display("failed to build Labels"))]
+    LabelBuild {
+        source: stackable_operator::kvp::LabelError,
+    },
+}
+
+/// The rolegroup headless [`Service`] is a service that allows direct access to the instances of a certain rolegroup
+/// This is mostly useful for internal communication between peers, or for clients that perform client-side load balancing.
+pub fn build_rolegroup_headless_service(
+    airflow: &v1alpha1::AirflowCluster,
+    rolegroup_ref: &RoleGroupRef<v1alpha1::AirflowCluster>,
+    object_labels: ObjectLabels<v1alpha1::AirflowCluster>,
+    selector: BTreeMap<String, String>,
+) -> Result<Service, Error> {
+    let ports = headless_service_ports();
+
+    let metadata = ObjectMetaBuilder::new()
+        .name_and_namespace(airflow)
+        .name(rolegroup_headless_service_name(
+            &rolegroup_ref.object_name(),
+        ))
+        .ownerreference_from_resource(airflow, None, Some(true))
+        .context(ObjectMissingMetadataForOwnerRefSnafu)?
+        .with_recommended_labels(object_labels)
+        .context(MetadataBuildSnafu)?
+        .build();
+
+    let service_spec = ServiceSpec {
+        // Internal communication does not need to be exposed
+        type_: Some("ClusterIP".to_string()),
+        cluster_ip: Some("None".to_string()),
+        ports: Some(ports),
+        selector: Some(selector),
+        publish_not_ready_addresses: Some(true),
+        ..ServiceSpec::default()
+    };
+
+    Ok(Service {
+        metadata,
+        spec: Some(service_spec),
+        status: None,
+    })
+}
+
+/// The rolegroup metrics [`Service`] is a service that exposes metrics and a prometheus scraping label.
+pub fn build_rolegroup_metrics_service(
+    airflow: &v1alpha1::AirflowCluster,
+    rolegroup_ref: &RoleGroupRef<v1alpha1::AirflowCluster>,
+    object_labels: ObjectLabels<v1alpha1::AirflowCluster>,
+    selector: BTreeMap<String, String>,
+) -> Result<Service, Error> {
+    let ports = metrics_service_ports();
+
+    let prometheus_label =
+        Label::try_from(("prometheus.io/scrape", "true")).context(LabelBuildSnafu)?;
+
+    let metadata = ObjectMetaBuilder::new()
+        .name_and_namespace(airflow)
+        .name(rolegroup_metrics_service_name(&rolegroup_ref.object_name()))
+        .ownerreference_from_resource(airflow, None, Some(true))
+        .context(ObjectMissingMetadataForOwnerRefSnafu)?
+        .with_recommended_labels(object_labels)
+        .context(MetadataBuildSnafu)?
+        .with_label(prometheus_label)
+        .build();
+
+    let service_spec = ServiceSpec {
+        // Internal communication does not need to be exposed
+        type_: Some("ClusterIP".to_string()),
+        cluster_ip: Some("None".to_string()),
+        ports: Some(ports),
+        selector: Some(selector),
+        publish_not_ready_addresses: Some(true),
+        ..ServiceSpec::default()
+    };
+
+    Ok(Service {
+        metadata,
+        spec: Some(service_spec),
+        status: None,
+    })
+}
+
+pub fn stateful_set_service_name(
+    airflow_role: &AirflowRole,
+    rolegroup_ref: &RoleGroupRef<v1alpha1::AirflowCluster>,
+) -> Option<String> {
+    match airflow_role {
+        AirflowRole::Webserver => Some(rolegroup_headless_service_name(
+            &rolegroup_ref.object_name(),
+        )),
+        AirflowRole::Scheduler | AirflowRole::Worker => None,
+    }
+}
+
+/// Returns the metrics rolegroup service name `<cluster>-<role>-<rolegroup>-<METRICS_SERVICE_SUFFIX>`.
+fn rolegroup_metrics_service_name(role_group_ref_object_name: &str) -> String {
+    format!("{role_group_ref_object_name}-{METRICS_SERVICE_SUFFIX}")
+}
+
+/// Returns the headless rolegroup service name `<cluster>-<role>-<rolegroup>-<HEADLESS_SERVICE_SUFFIX>`.
+fn rolegroup_headless_service_name(role_group_ref_object_name: &str) -> String {
+    format!("{role_group_ref_object_name}-{HEADLESS_SERVICE_SUFFIX}")
+}
+
+fn headless_service_ports() -> Vec<ServicePort> {
+    vec![ServicePort {
+        name: Some(HTTP_PORT_NAME.to_string()),
+        port: HTTP_PORT.into(),
+        protocol: Some("TCP".to_string()),
+        ..ServicePort::default()
+    }]
+}
+
+fn metrics_service_ports() -> Vec<ServicePort> {
+    vec![ServicePort {
+        name: Some(METRICS_PORT_NAME.to_string()),
+        port: METRICS_PORT.into(),
+        protocol: Some("TCP".to_string()),
+        ..ServicePort::default()
+    }]
+}


### PR DESCRIPTION
## Description

- split internal services into metrics and headless
- currently only the webserver has a headless service

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
