### PR TITLE
fix(docs): Update getting-started script pre-25.7.0

### DIFF
--- a/docs/modules/airflow/examples/getting_started/code/airflow.yaml
+++ b/docs/modules/airflow/examples/getting_started/code/airflow.yaml
@@ -20,13 +20,6 @@ spec:
     roleGroups:
       default:
         replicas: 2
-    config:
-      resources:
-        cpu:
-          min: 400m
-          max: 800m
-        memory:
-          limit: 2Gi
   schedulers:
     roleGroups:
       default:


### PR DESCRIPTION
Part of <https://github.com/stackabletech/issues/issues/742>

With this change, the DAG now runs successfully. Previously, it ran out of resources. See https://github.com/stackabletech/issues/issues/742#issuecomment-3068604715 for more context.