### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
   - The default Kubernetes cluster domain name is now fetched from the kubelet API unless explicitly configured.
   - This requires operators to have the RBAC permission to get nodes/proxy in the apiGroup "". The helm-chart takes care of this.
   - The CLI argument `--kubernetes-node-name` or env variable `KUBERNETES_NODE_NAME` needs to be set. The helm-chart takes care of this.
+- The operator helm-chart now grants RBAC `patch` permissions on `events.k8s.io/events`.
+  This applies to the operator and the product ClusterRole, in the future we might be able to remove the `events`
+  permissions for the product entirely ([#660]).
 
 ### Fixed
 
@@ -66,6 +69,7 @@
 [#649]: https://github.com/stackabletech/airflow-operator/pull/649
 [#651]: https://github.com/stackabletech/airflow-operator/pull/651
 [#656]: https://github.com/stackabletech/airflow-operator/pull/656
+[#660]: https://github.com/stackabletech/airflow-operator/pull/660
 
 ## [25.3.0] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,8 @@
   - The default Kubernetes cluster domain name is now fetched from the kubelet API unless explicitly configured.
   - This requires operators to have the RBAC permission to get nodes/proxy in the apiGroup "". The helm-chart takes care of this.
   - The CLI argument `--kubernetes-node-name` or env variable `KUBERNETES_NODE_NAME` needs to be set. The helm-chart takes care of this.
-- The operator helm-chart now grants RBAC `patch` permissions on `events.k8s.io/events`.
-  This applies to the operator and the product ClusterRole, in the future we might be able to remove the `events`
-  permissions for the product entirely ([#660]).
+- The operator helm-chart now grants RBAC `patch` permissions on `events.k8s.io/events`,
+  so events can be aggregated (e.g. "error happened 10 times over the last 5 minutes") ([#660]).
 
 ### Fixed
 

--- a/deploy/helm/airflow-operator/templates/roles.yaml
+++ b/deploy/helm/airflow-operator/templates/roles.yaml
@@ -180,6 +180,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   - apiGroups:
       - security.openshift.io


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.