### PR TITLE
fix(getting_started): Add timeout before enabling DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- getting_started: Add a 120 second timeout before trying to enable the DAG ([#665]).
+
+[#665]: https://github.com/stackabletech/airflow-operator/pull/665
+
 ## [25.7.0] - 2025-07-23
 
 ## [25.7.0-rc1] - 2025-07-18

--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh
@@ -122,6 +122,9 @@ enable_dag() {
     -d '{"is_paused": false}'
   # end::enable-dag[]
 }
+SLEEP_SECONDS=120
+echo "Sleeping for $SLEEP_SECONDS seconds to wait for the DAG to be registered"
+sleep "$SLEEP_SECONDS"
 echo "Triggering a DAG run. Enable DAG..."
 enable_dag
 

--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
@@ -122,6 +122,9 @@ enable_dag() {
     -d '{"is_paused": false}'
   # end::enable-dag[]
 }
+SLEEP_SECONDS=120
+echo "Sleeping for $SLEEP_SECONDS seconds to wait for the DAG to be registered"
+sleep "$SLEEP_SECONDS"
 echo "Triggering a DAG run. Enable DAG..."
 enable_dag
 


### PR DESCRIPTION
Without this, there is a high chance of hitting this error:

```
We have a healthy webserver!
Triggering a DAG run. Enable DAG...
{
  "detail": null,
  "status": 404,
  "title": "Dag with id: 'example_trigger_target_dag' not found",
  "type": "https://airflow.apache.org/docs/apache-airflow/2.10.5/stable-rest-api-ref.html#section/Errors/NotFound"
}
Checking DAG result ...
The DAG was not successful. State:  null
```