### PR TITLE
chore: update docs and examples to use bitnamilegacy

### DIFF
--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh
@@ -21,6 +21,10 @@ echo "Adding bitnami Helm Chart repository and dependencies (Postgresql and Redi
 # tag::helm-add-bitnami-pgs[]
 helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version 16.5.0 \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.database=airflow \
   --set auth.username=airflow \
   --set auth.password=airflow \
@@ -29,6 +33,13 @@ helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgre
 # tag::helm-add-bitnami-redis[]
 helm install airflow-redis oci://registry-1.docker.io/bitnamicharts/redis \
   --version 20.11.3 \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/redis \
+  --set sentinel.image.repository=bitnamilegacy/redis-sentinel \
+  --set metrics.image.repository=bitnamilegacy/redis-exporter \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set kubectl.image.repository=bitnamilegacy/kubectl \
+  --set sysctl.image.repository=bitnamilegacy/os-shell \
   --set replica.replicaCount=1 \
   --set auth.password=redis \
   --wait

--- a/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/airflow/examples/getting_started/code/getting_started.sh.j2
@@ -21,6 +21,10 @@ echo "Adding bitnami Helm Chart repository and dependencies (Postgresql and Redi
 # tag::helm-add-bitnami-pgs[]
 helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version {{ versions.postgresql }} \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.database=airflow \
   --set auth.username=airflow \
   --set auth.password=airflow \
@@ -29,6 +33,13 @@ helm install airflow-postgresql oci://registry-1.docker.io/bitnamicharts/postgre
 # tag::helm-add-bitnami-redis[]
 helm install airflow-redis oci://registry-1.docker.io/bitnamicharts/redis \
   --version {{ versions.redis }} \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/redis \
+  --set sentinel.image.repository=bitnamilegacy/redis-sentinel \
+  --set metrics.image.repository=bitnamilegacy/redis-exporter \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set kubectl.image.repository=bitnamilegacy/kubectl \
+  --set sysctl.image.repository=bitnamilegacy/os-shell \
   --set replica.replicaCount=1 \
   --set auth.password=redis \
   --wait

--- a/examples/simple-airflow-cluster-ldap-insecure-tls.yaml
+++ b/examples/simple-airflow-cluster-ldap-insecure-tls.yaml
@@ -1,7 +1,9 @@
 # helm install secret-operator oci://oci.stackable.tech/sdp-charts/secret-operator
 # helm install commons-operator oci://oci.stackable.tech/sdp-charts/commons-operator
-# helm install --repo https://charts.bitnami.com/bitnami --version 12.1.5 --set auth.username=airflow --set auth.password=airflow --set auth.database=airflow airflow-postgresql postgresql
-# helm install --repo https://charts.bitnami.com/bitnami --version 17.3.7 --set auth.password=redis --set replica.replicaCount=1 airflow-redis redis
+# helm install listener-operator oci://oci.stackable.tech/sdp-charts/listener-operator
+# helm install airflow-operator oci://oci.stackable.tech/sdp-charts/airflow-operator
+# helm install --repo https://charts.bitnami.com/bitnami --version 12.1.5 --set auth.username=airflow --set auth.password=airflow --set auth.database=airflow  --set image.repository=bitnamilegacy/postgresql --set volumePermissions.image.repository=bitnamilegacy/os-shell --set metrics.image.repository=bitnamilegacy/postgres-exporter --set global.security.allowInsecureImages=true airflow-postgresql postgresql
+# helm install --repo https://charts.bitnami.com/bitnami --version 17.3.7 --set auth.password=redis --set replica.replicaCount=1 --set global.security.allowInsecureImages=true --set image.repository=bitnamilegacy/redis --set sentinel.image.repository=bitnamilegacy/redis-sentinel --set metrics.image.repository=bitnamilegacy/redis-exporter --set volumePermissions.image.repository=bitnamilegacy/os-shell --set kubectl.image.repository=bitnamilegacy/kubectl --set sysctl.image.repository=bitnamilegacy/os-shell airflow-redis redis
 # Log in with user01/user01 or user02/user02
 ---
 apiVersion: secrets.stackable.tech/v1alpha1
@@ -36,7 +38,7 @@ spec:
     spec:
       containers:
         - name: openldap
-          image: docker.io/bitnami/openldap:2.5
+          image: docker.io/bitnamilegacy/openldap:2.5
           env:
             - name: LDAP_ADMIN_USERNAME
               value: admin

--- a/examples/simple-airflow-cluster-ldap.yaml
+++ b/examples/simple-airflow-cluster-ldap.yaml
@@ -1,7 +1,9 @@
 # helm install secret-operator oci://oci.stackable.tech/sdp-charts/secret-operator
 # helm install commons-operator oci://oci.stackable.tech/sdp-charts/commons-operator
-# helm install --repo https://charts.bitnami.com/bitnami --version 12.1.5 --set auth.username=airflow --set auth.password=airflow --set auth.database=airflow airflow-postgresql postgresql
-# helm install --repo https://charts.bitnami.com/bitnami --version 17.3.7 --set auth.password=redis --set replica.replicaCount=1 airflow-redis redis
+# helm install listener-operator oci://oci.stackable.tech/sdp-charts/listener-operator
+# helm install airflow-operator oci://oci.stackable.tech/sdp-charts/airflow-operator
+# helm install --repo https://charts.bitnami.com/bitnami --version 12.1.5 --set auth.username=airflow --set auth.password=airflow --set auth.database=airflow --set image.repository=bitnamilegacy/postgresql --set volumePermissions.image.repository=bitnamilegacy/os-shell --set metrics.image.repository=bitnamilegacy/postgres-exporter --set global.security.allowInsecureImages=true airflow-postgresql postgresql
+# helm install --repo https://charts.bitnami.com/bitnami --version 17.3.7 --set auth.password=redis --set replica.replicaCount=1 --set global.security.allowInsecureImages=true --set image.repository=bitnamilegacy/redis --set sentinel.image.repository=bitnamilegacy/redis-sentinel --set metrics.image.repository=bitnamilegacy/redis-exporter --set volumePermissions.image.repository=bitnamilegacy/os-shell --set kubectl.image.repository=bitnamilegacy/kubectl --set sysctl.image.repository=bitnamilegacy/os-shell airflow-redis redis
 # Log in with user01/user01 or user02/user02
 ---
 apiVersion: secrets.stackable.tech/v1alpha1
@@ -36,7 +38,7 @@ spec:
     spec:
       containers:
         - name: openldap
-          image: docker.io/bitnami/openldap:2.5
+          image: docker.io/bitnamilegacy/openldap:2.5
           env:
             - name: LDAP_ADMIN_USERNAME
               value: admin


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 and follow up to https://github.com/stackabletech/airflow-operator/pull/670
This PR updates the docs and examples of the 25.7 release to use bitnamilegacy.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
