### PR TITLE
chore: Bump opa version for 25.11.0

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -19,7 +19,7 @@ dimensions:
       # - 3.0.1,oci.stackable.tech/sandbox/airflow:3.0.1-stackable0.0.0-dev
   - name: opa-latest
     values:
-      - 1.4.2
+      - 1.8.0
   - name: ldap-authentication
     values:
       - no-tls


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1238

### Integrationtests

```
--- PASS: kuttl (447.82s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/opa_airflow-3.0.1_opa-latest-1.8.0_openshift-false (222.74s)
        --- PASS: kuttl/harness/opa_airflow-2.10.4_opa-latest-1.8.0_openshift-false (222.97s)
        --- PASS: kuttl/harness/opa_airflow-2.10.5_opa-latest-1.8.0_openshift-false (225.07s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
