### PR TITLE
fix: Set FERNET_KEY to prevent connections from crashing webservers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   Previously, the operator would always use the same name for the executor Pod template ConfigMap.
   Thus when deploying multiple Airflow instances in the same namespace, there would be a conflict over the contents of that ConfigMap ([#678]).
 - For versions >= 3 custom logging initializes the RemoteLogIO handler to fix remote logging ([#683]).
+- Prevent Airflow connections from breaking in combination with Airflow 3.
+  This was achieved by setting the `AIRFLOW__CORE__FERNET_KEY` env var ([#XXX]).
 
 ### Removed
 
@@ -42,6 +44,7 @@
 [#690]: https://github.com/stackabletech/airflow-operator/pull/690
 [#691]: https://github.com/stackabletech/airflow-operator/pull/691
 [#692]: https://github.com/stackabletech/airflow-operator/pull/692
+[#XXX]: https://github.com/stackabletech/airflow-operator/pull/XXX
 
 ## [25.7.0] - 2025-07-23
 

--- a/rust/operator-binary/src/crd/internal_secret.rs
+++ b/rust/operator-binary/src/crd/internal_secret.rs
@@ -16,12 +16,15 @@ use crate::{airflow_controller::AIRFLOW_CONTROLLER_NAME, crd::v1alpha1};
 // Secret key used to run the api server. It should be as random as possible.
 // It should be consistent across instances of the webserver. The webserver key
 // is also used to authorize requests to Celery workers when logs are retrieved.
-pub const ENV_INTERNAL_SECRET: &str = "INTERNAL_SECRET";
+pub const INTERNAL_SECRET_SECRET_KEY: &str = "INTERNAL_SECRET";
 // Used for env-var: AIRFLOW__API_AUTH__JWT_SECRET
 // Secret key used to encode and decode JWTs to authenticate to public and
 // private APIs. It should be as random as possible, but consistent across
 // instances of API services.
-pub const ENV_JWT_SECRET: &str = "JWT_SECRET";
+pub const JWT_SECRET_SECRET_KEY: &str = "JWT_SECRET";
+// Used for env-var: AIRFLOW__CORE__FERNET_KEY
+// See https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/fernet.html#security-fernet
+pub const FERNET_KEY_SECRET_KEY: &str = "FERNET_KEY";
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -454,12 +454,16 @@ impl v1alpha1::AirflowCluster {
         fragment::validate(conf_executor).context(FragmentValidationFailureSnafu)
     }
 
-    pub fn shared_internal_secret_name(&self) -> String {
+    pub fn shared_internal_secret_secret_name(&self) -> String {
         format!("{}-internal-secret", &self.name_any())
     }
 
-    pub fn shared_jwt_secret_name(&self) -> String {
+    pub fn shared_jwt_secret_secret_name(&self) -> String {
         format!("{}-jwt-secret", &self.name_any())
+    }
+
+    pub fn shared_fernet_key_secret_name(&self) -> String {
+        format!("{}-fernet-key", &self.name_any())
     }
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/stackabletech/airflow-operator/issues/694

Also did a bit of renaming variables to better reflect their prupose

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
