### PR TITLE
docs: Add usage guide on how to submit some tasks locally instead of k8s

### DIFF
--- a/docs/modules/airflow/pages/usage-guide/using-kubernetes-executors.adoc
+++ b/docs/modules/airflow/pages/usage-guide/using-kubernetes-executors.adoc
@@ -33,10 +33,10 @@ spec:
 
 == Task startup latency
 
-While it has many benefits to spawn a dedicated Pod for every task, this introduces some latency.
+While there are many benefits to spawning a dedicated Pod for every task, this introduces some latency.
 The shorter the actual task runs, the higher the effect of this latency get's on the overall DAG runtime.
 
-If your tasks don't do computational expensive things (e.g. only submit a query to a Trino cluster), you can schedule them to run locally (on the scheduler) and not spawn a Pod to reduce the DAG runtime.
+If your tasks don't do computationally expensive things (e.g. only submit a query to a Trino cluster), you can schedule them to run locally (on the scheduler) and not spawn a Pod to reduce the DAG runtime.
 
 To achieve this enable the `LocalExecutor` in your Airflow stacklet with
 


### PR DESCRIPTION
Came out of a customer DAG speedup session :)