### PR TITLE
docs: Removed unsupported db (mysql)

### DIFF
--- a/docs/modules/airflow/pages/required-external-components.adoc
+++ b/docs/modules/airflow/pages/required-external-components.adoc
@@ -9,7 +9,8 @@ Fully supported for production usage:
 
 * PostgreSQL: 12, 13, 14, 15, 16
 
-NOTE: while Airflow also supports MySQL and bundles a provider for its use, SDP does not support it due to additional internal dependencies.
+NOTE: The SDP Airflow images do not bundle the MySQL provider for Airflow.
+If you need MySQL or MariaDB as an Airflow back-end, you will need to create a custom image to include this provider.
 
 The Celery exectutor also requires:
 


### PR DESCRIPTION
## Description

We do not package the mysql provider due to a required dependency. See [here](https://github.com/stackabletech/docker-images/blob/main/airflow/README.md?plain=1#L36). The docs should reflect this.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
