### PR TITLE
chore: Remove unused RBAC permission for product role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- Document Helm deployed RBAC permissions and remove unnecessary permissions ([#767]).
+- Document Helm deployed RBAC permissions and remove unnecessary permissions ([#767], [#774]).
 
 ### Fixed
 
@@ -19,6 +19,7 @@
 [#765]: https://github.com/stackabletech/airflow-operator/pull/765
 [#767]: https://github.com/stackabletech/airflow-operator/pull/767
 [#770]: https://github.com/stackabletech/airflow-operator/pull/770
+[#774]: https://github.com/stackabletech/airflow-operator/pull/774
 
 ## [26.3.0] - 2026-03-16
 

--- a/deploy/helm/airflow-operator/templates/clusterrole-product.yaml
+++ b/deploy/helm/airflow-operator/templates/clusterrole-product.yaml
@@ -28,14 +28,6 @@ rules:
       - pods/log
     verbs:
       - get
-  # Airflow components publish Kubernetes events
-  - apiGroups:
-      - events.k8s.io
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   # On OpenShift: allows workload pods to use the nonroot-v2 SecurityContextConstraint
   - apiGroups:


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/798

Follow up of https://github.com/stackabletech/airflow-operator/pull/767/changes#r3014650545

<details>

The events rule in the product ClusterRole (lines 31-38) looks safe to remove. Here's why:

1. **Airflow does not publish Kubernetes events.** No Airflow component (scheduler, webserver, worker, etc.) calls `create_namespaced_event` or uses `EventsV1Api` to create Event objects.
2. **Airflow only reads events, optionally.** The `KubernetesPodOperator` can read events for failed pods via `CoreV1Api.list_namespaced_event` (core `""` API group, not `events.k8s.io`), and even that is off by default in the official Airflow Helm chart.
3. **The comment is inaccurate.** "Airflow components publish Kubernetes events" - they don't. The *operator* publishes events (that's correctly handled in `clusterrole-operator.yaml`), but the workload pods don't.
4. **The official Airflow Helm chart** only grants `get`/`list` on core API events, and makes even that optional (`rbac.events = false` by default).


</details>