### PR TITLE
chore!: Rename EXPERIMENTAL_FILE_HEADER / EXPERIMENTAL_FILE_FOOTER in webserver_config.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Document Helm deployed RBAC permissions and remove unnecessary permissions ([#767], [#774]).
 - BREAKING: `configOverrides` now only accepts the known config file `webserver_config.py`. Previously, arbitrary file names were silently accepted and ignored ([#775]).
 - Bump `stackable-operator` to 0.110.1, kube to 3.1.0, and snafu to 0.9 ([#775]).
-- BREAKING: Renaming `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `webserver_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([]).
+- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `webserver_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([#777]).
 
 ### Fixed
 
@@ -24,6 +24,7 @@
 [#770]: https://github.com/stackabletech/airflow-operator/pull/770
 [#774]: https://github.com/stackabletech/airflow-operator/pull/774
 [#775]: https://github.com/stackabletech/airflow-operator/pull/775
+[#777]: https://github.com/stackabletech/airflow-operator/pull/777
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Document Helm deployed RBAC permissions and remove unnecessary permissions ([#767], [#774]).
 - BREAKING: `configOverrides` now only accepts the known config file `webserver_config.py`. Previously, arbitrary file names were silently accepted and ignored ([#775]).
 - Bump `stackable-operator` to 0.110.1, kube to 3.1.0, and snafu to 0.9 ([#775]).
+- BREAKING: Renaming `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `webserver_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Document Helm deployed RBAC permissions and remove unnecessary permissions ([#767], [#774]).
 - BREAKING: `configOverrides` now only accepts the known config file `webserver_config.py`. Previously, arbitrary file names were silently accepted and ignored ([#775]).
 - Bump `stackable-operator` to 0.110.1, kube to 3.1.0, and snafu to 0.9 ([#775]).
-- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `webserver_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([#777]).
+- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `webserver_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([#775], [#777]).
 
 ### Fixed
 

--- a/docs/modules/airflow/pages/usage-guide/overrides.adoc
+++ b/docs/modules/airflow/pages/usage-guide/overrides.adoc
@@ -14,7 +14,7 @@ Not all roles use each setting, but some things -- such as external endpoints --
 Airflow exposes an environment variable for every Airflow configuration setting, a list of which can be found in the {airflow-config-docs}[Configuration Reference].
 
 As Airflow can be configured with python code too, arbitrary code can be added to the `webserver_config.py`.
-You can use either `EXPERIMENTAL_FILE_HEADER` to add code to the top or `EXPERIMENTAL_FILE_FOOTER` to add to the bottom.
+You can use either `FILE_HEADER` to add code to the top or `FILE_FOOTER` to add to the bottom.
 
 IMPORTANT: This is an experimental feature.
 
@@ -24,9 +24,9 @@ webservers:
   configOverrides:
     webserver_config.py:
       CSV_EXPORT: "{'encoding': 'utf-8'}"
-      EXPERIMENTAL_FILE_HEADER: |
+      FILE_HEADER: |
         from modules.my_module import my_class
-      EXPERIMENTAL_FILE_FOOTER: |
+      FILE_FOOTER: |
         import logging
         from airflow.security import AirflowSecurityManager
 

--- a/tests/templates/kuttl/smoke/40-install-airflow-cluster.yaml.j2
+++ b/tests/templates/kuttl/smoke/40-install-airflow-cluster.yaml.j2
@@ -48,17 +48,17 @@ spec:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     configOverrides:
       webserver_config.py:
-        EXPERIMENTAL_FILE_HEADER: |
+        FILE_HEADER: |
           COMMON_HEADER_VAR = "role-value"
           ROLE_HEADER_VAR = "role-value"
-        EXPERIMENTAL_FILE_FOOTER: |
+        FILE_FOOTER: |
           ROLE_FOOTER_VAR = "role-value"
     roleGroups:
       default:
         replicas: 1
         configOverrides:
           webserver_config.py:
-            EXPERIMENTAL_FILE_HEADER: |
+            FILE_HEADER: |
               COMMON_HEADER_VAR = "group-value"
 {% if test_scenario['values']['executor'] == 'celery' %}
   celeryExecutors:

--- a/tests/templates/kuttl/smoke/41-assert.yaml
+++ b/tests/templates/kuttl/smoke/41-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 300
 commands:
   #
   # Test envOverrides
@@ -16,6 +16,6 @@ commands:
       )
 
       # Config Test Assertions
-      echo "$AIRFLOW_CONFIG" | grep 'COMMON_HEADER_VAR = "group-value"'
-      echo "$AIRFLOW_CONFIG" | grep 'ROLE_FOOTER_VAR = "role-value"'
-      echo "$AIRFLOW_CONFIG" | grep -v 'ROLE_HEADER_VAR = "role-value"'
+      echo "$AIRFLOW_CONFIG" | grep '^COMMON_HEADER_VAR = "group-value"'
+      echo "$AIRFLOW_CONFIG" | grep '^ROLE_FOOTER_VAR = "role-value"'
+      echo "$AIRFLOW_CONFIG" | grep -v '^ROLE_HEADER_VAR = "role-value"'


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/836

- Removes `EXPERIMENTAL_` prefix from documentation and test
- Adjust test to actually catch the proper setting of the header / footer
- Add Changelog entry (actual removal of prefix was done in https://github.com/stackabletech/operator-rs/pull/1191)

### Integrationtests

```
--- PASS: kuttl (642.10s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_airflow-2.9.3_openshift-false_executor-celery (190.47s)
        --- PASS: kuttl/harness/smoke_airflow-3.0.6_openshift-false_executor-kubernetes (194.24s)
        --- PASS: kuttl/harness/smoke_airflow-3.1.6_openshift-false_executor-kubernetes (197.74s)
        --- PASS: kuttl/harness/smoke_airflow-3.0.6_openshift-false_executor-celery (201.77s)
        --- PASS: kuttl/harness/smoke_airflow-2.9.3_openshift-false_executor-kubernetes (165.00s)
        --- PASS: kuttl/harness/smoke_airflow-3.1.6_openshift-false_executor-celery (250.11s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
