### PR TITLE
fix: Add cleanup steps to prevent kuttl namespace deletion timeouts

### DIFF
--- a/tests/templates/kuttl/ca-cert/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/ca-cert/90-cleanup-executor-pods.yaml
@@ -1,0 +1,18 @@
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster --all -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/external-access/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/external-access/90-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/ldap/99-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/ldap/99-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/logging/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/logging/90-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/mount-dags-configmap/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-configmap/90-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/mount-dags-gitsync/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/90-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/oidc/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/oidc/90-cleanup-executor-pods.yaml
@@ -1,0 +1,18 @@
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/opa/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/opa/90-cleanup-executor-pods.yaml
@@ -1,0 +1,18 @@
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/overrides/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/overrides/90-cleanup-executor-pods.yaml
@@ -1,0 +1,18 @@
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster --all -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/remote-logging/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/remote-logging/90-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/triggerer/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/triggerer/90-cleanup-executor-pods.yaml.j2
@@ -1,0 +1,20 @@
+{% if test_scenario['values']['executor'] == 'kubernetes' %}
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+{% endif %}

--- a/tests/templates/kuttl/versioning/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/versioning/90-cleanup-executor-pods.yaml
@@ -1,0 +1,18 @@
+---
+# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
+# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
+# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
+# namespace deletion past kuttl's timeout.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s


### PR DESCRIPTION
## Summary
- Add a final cleanup test step to all 13 kuttl test suites that use (or may use)
  the KubernetesExecutor, to prevent namespace deletion timeouts.
- The cleanup deletes the AirflowCluster CR (triggering orderly StatefulSet scale-down),
  waits up to 120s for pods to terminate, then force-deletes any stragglers.
- Conditional (`.yaml.j2`) for tests that parameterise the executor type; unconditional
  (`.yaml`) for tests that always use the KubernetesExecutor.

## Root cause
The Vector sidecar container in KubernetesExecutor DAG task pods runs Vector as a
background process (`vector ... &`), with bash as PID 1. When SIGTERM arrives during
namespace deletion:
1. Bash (PID 1) receives SIGTERM but has no trap — it waits for children.
2. Vector (not PID 1) ignores SIGTERM entirely.
3. The `_STACKABLE_POST_HOOK` in the base container (`sleep 10; touch shutdown`) fails
   because `sleep` itself gets killed by SIGTERM before creating the shutdown file.
4. The pod sits in Terminating for the full `terminationGracePeriodSeconds` (300s).

This was not visible before the kuttl v0.11.1 → v0.20.0 bump (2026-04-22), because
kuttl v0.11.1 fired namespace deletion and moved on without waiting.

## Proper fix (operator-rs)
This PR is a **workaround**. The proper fix belongs in `operator-rs`
(`crates/stackable-operator/src/product_logging/framework.rs`, around line 1444).
There is already a commented-out alternative in the code (lines 1440–1443) that
uses `exec` to make Vector PID 1 so it receives and handles SIGTERM directly:

```rust
// bash -c 'sleep 1 && if [ ! -f "...shutdown" ]; then mkdir -p ... && inotifywait ...; fi && kill 1' &
// exec vector --config ...
```

This approach should be completed and enabled. Once that fix lands in operator-rs,
these cleanup steps can be removed.

## Test plan
- [x] Ran all 11 KubernetesExecutor test variants locally with cleanup steps
- [x] Critical test (KE + Vector logging) namespace Terminating time dropped from ~7 min to ~54s
- [x] CeleryExecutor variants unaffected (Jinja2 conditional renders empty file)
- [x] No test failures introduced

```
--- PASS: kuttl (3524.76s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/mount-dags-configmap_airflow-latest-3.1.6_openshift-false_executor-kubernetes (318.34s)
        --- PASS: kuttl/harness/ldap_airflow-latest-3.1.6_ldap-authentication-server-verification-tls_openshift-false_executor-kubernetes (223.52s)
        --- PASS: kuttl/harness/remote-logging_airflow-latest-3.1.6_openshift-false_executor-kubernetes (339.06s)
        --- PASS: kuttl/harness/external-access_airflow-3.1.6_openshift-false_executor-kubernetes (175.36s)
        --- PASS: kuttl/harness/triggerer_airflow-latest-3.1.6_openshift-false_executor-kubernetes (251.92s)
        --- PASS: kuttl/harness/smoke_airflow-3.1.6_openshift-false_executor-kubernetes (211.90s)
        --- PASS: kuttl/harness/logging_airflow-3.1.6_openshift-false_executor-kubernetes (615.99s)
        --- PASS: kuttl/harness/ldap_airflow-latest-3.1.6_ldap-authentication-no-tls_openshift-false_executor-kubernetes (212.74s)
        --- PASS: kuttl/harness/ldap_airflow-latest-3.1.6_ldap-authentication-insecure-tls_openshift-false_executor-kubernetes (338.48s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-3.1.6_openshift-false_executor-kubernetes_access-ssh (420.55s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-3.1.6_openshift-false_executor-kubernetes_access-https (416.58s)
PASS

--- PASS: kuttl (433.99s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/versioning_airflow-latest-3.1.6_openshift-false (433.64s)
PASS
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)