### PR TITLE
fix: Replace DummyOperator by EmptyOperator in docs

### DIFF
--- a/docs/modules/airflow/examples/example-configmap.yaml
+++ b/docs/modules/airflow/examples/example-configmap.yaml
@@ -8,7 +8,7 @@ data:
     from datetime import datetime, timedelta
     from airflow import DAG
     from airflow.operators.bash import BashOperator
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.empty import EmptyOperator
 
     with DAG(
         dag_id='test_airflow_dag',
@@ -19,7 +19,7 @@ data:
         tags=['example', 'example2'],
         params={"example_key": "example_value"},
     ) as dag:
-        run_this_last = DummyOperator(
+        run_this_last = EmptyOperator(
             task_id='run_this_last',
         )
 

--- a/docs/modules/airflow/examples/example-configmap.yaml
+++ b/docs/modules/airflow/examples/example-configmap.yaml
@@ -7,8 +7,8 @@ data:
   test_airflow_dag.py: | # <2>
     from datetime import datetime, timedelta
     from airflow import DAG
-    from airflow.operators.bash import BashOperator
-    from airflow.operators.empty import EmptyOperator
+    from airflow.providers.standard.operators.bash import BashOperator
+    from airflow.providers.standard.operators.empty import EmptyOperator
 
     with DAG(
         dag_id='test_airflow_dag',


### PR DESCRIPTION
## Description

Minor documentation update since DummyOperator was removed.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
