### PR TITLE
chore: Bump vector to 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   The results backend `spec.celeryExecutors.resultBackend` is now `spec.clusterConfig.celeryResultsBackend`.
   The broker `spec.celeryExecutors.broker` is now `spec.clusterConfig.celeryBroker`.
 - Internal operator refactoring: introduce dereference() and validate() steps in the reconciler ([#795]).
+- test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#801]).
 
 ### Fixed
 
@@ -39,6 +40,7 @@
 [#784]: https://github.com/stackabletech/airflow-operator/pull/784
 [#786]: https://github.com/stackabletech/airflow-operator/pull/786
 [#795]: https://github.com/stackabletech/airflow-operator/pull/795
+[#801]: https://github.com/stackabletech/airflow-operator/pull/801
 
 ## [26.3.0] - 2026-03-16
 

--- a/tests/templates/kuttl/logging/30-install-airflow-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/30-install-airflow-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install airflow-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.49.0
+      --version 0.52.0 `# app version 0.55.0`
       --repo https://helm.vector.dev
       --values airflow-vector-aggregator-values.yaml
 ---

--- a/tests/templates/kuttl/logging/test_log_aggregation.py
+++ b/tests/templates/kuttl/logging/test_log_aggregation.py
@@ -1,45 +1,40 @@
-#!/usr/bin/env python3
-import requests
+import json
+import subprocess
 
 
 def check_sent_events():
-    response = requests.post(
-        "http://airflow-vector-aggregator:8686/graphql",
-        json={
-            "query": """
-                {
-                    transforms(first:100) {
-                        nodes {
-                            componentId
-                            metrics {
-                                sentEventsTotal {
-                                    sentEventsTotal
-                                }
-                            }
-                        }
-                    }
-                }
-            """
-        },
+    response = subprocess.run(
+        [
+            "grpcurl",
+            "-plaintext",
+            "-d",
+            '{"limit": 100}',
+            "airflow-vector-aggregator:8686",
+            "vector.observability.v1.ObservabilityService/GetComponents",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,  # Raise a CalledProcessError if non-zero return
+        timeout=20,  # seconds
     )
+    result = json.loads(response.stdout)
+    components = result.get("components", [])
+    transforms = [
+        c for c in components if c.get("componentType") == "COMPONENT_TYPE_TRANSFORM"
+    ]
 
-    assert response.status_code == 200, (
-        "Cannot access the API of the vector aggregator."
-    )
+    assert len(transforms) > 0, "No transform components found"
 
-    result = response.json()
-
-    transforms = result["data"]["transforms"]["nodes"]
     for transform in transforms:
         sentEvents = transform["metrics"]["sentEventsTotal"]
         componentId = transform["componentId"]
 
         if componentId == "filteredInvalidEvents":
-            assert sentEvents is None or sentEvents["sentEventsTotal"] == 0, (
+            assert sentEvents is None or int(sentEvents) == 0, (
                 "Invalid log events were sent."
             )
         else:
-            assert sentEvents is not None and sentEvents["sentEventsTotal"] > 0, (
+            assert sentEvents is not None and int(sentEvents) > 0, (
                 f'No events were sent in "{componentId}".'
             )
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1486

```
--- PASS: kuttl (1336.70s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/remote-logging_airflow-latest-3.1.6,oci.stackable.tech_sdp_airflow_3.1.6-stackable0.0.0-dev_openshift-false_executor-celery (209.61s)
        --- PASS: kuttl/harness/logging_airflow-3.1.6,oci.stackable.tech_sdp_airflow_3.1.6-stackable0.0.0-dev_openshift-false_executor-celery (308.53s)
        --- PASS: kuttl/harness/logging_airflow-3.1.6,oci.stackable.tech_sdp_airflow_3.1.6-stackable0.0.0-dev_openshift-false_executor-kubernetes (520.11s)
        --- PASS: kuttl/harness/remote-logging_airflow-latest-3.1.6,oci.stackable.tech_sdp_airflow_3.1.6-stackable0.0.0-dev_openshift-false_executor-kubernetes (298.44s)
PASS
```