### PR TITLE
chore: Replace Airflow 3.2.1 with 3.2.2

### DIFF
--- a/docs/modules/airflow/examples/getting_started/code/airflow.yaml
+++ b/docs/modules/airflow/examples/getting_started/code/airflow.yaml
@@ -5,7 +5,7 @@ metadata:
   name: airflow
 spec:
   image:
-    productVersion: 3.2.1
+    productVersion: 3.2.2
     pullPolicy: IfNotPresent
   clusterConfig:
     loadExamples: true

--- a/docs/modules/airflow/partials/supported-versions.adoc
+++ b/docs/modules/airflow/partials/supported-versions.adoc
@@ -2,7 +2,7 @@
 // This is a separate file, since it is used by both the direct Airflow-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
-- 3.2.1
+- 3.2.2
 - 3.1.6 (deprecated)
 - 3.0.6 (LTS)
 - 2.9.3 (deprecated)

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -10,12 +10,12 @@ dimensions:
       - 2.9.3
       - 3.0.6
       - 3.1.6
-      - 3.2.1
+      - 3.2.2
       # To use a custom image, add a comma and the full name after the product version
       # - x.x.x,oci.stackable.tech/sandbox/airflow:x.x.x-stackable0.0.0-dev
   - name: airflow-latest
     values:
-      - 3.2.1
+      - 3.2.2
       # To use a custom image, add a comma and the full name after the product version
       # - x.x.x,oci.stackable.tech/sandbox/airflow:x.x.x-stackable0.0.0-dev
   - name: opa-latest


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1543

No changelog as the are only small docs/test changes.