### PR TITLE
docs: Add FIXME note regarding smoke test teardown

### DIFF
--- a/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
@@ -5,6 +5,11 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# FIXME: This step also runs when kuttl is called with --skip-delete, so the
+# AirflowCluster is torn down even though the namespace is kept for debugging.
+# kuttl does not expose --skip-delete to test steps, so there is no clean way to
+# guard against it from here.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600


### PR DESCRIPTION
## Description

Follow-up of https://github.com/stackabletech/airflow-operator/pull/789

Maybe we already did the proper fix already and can get rid of this?

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
