### PR TITLE
fix(test): Don't tear down AirflowClusters when `--skip-delete` is used

### DIFF
--- a/tests/templates/kuttl/ca-cert/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/ca-cert/90-cleanup-executor-pods.yaml
@@ -4,13 +4,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster --all -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/ca-cert/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/ca-cert/90-cleanup-executor-pods.yaml
@@ -1,40 +1,8 @@
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster --all -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh

--- a/tests/templates/kuttl/commons/cleanup-executor-pods.sh
+++ b/tests/templates/kuttl/commons/cleanup-executor-pods.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+# Shared teardown for KubernetesExecutor tests: force-deletes leftover DAG task pods so
+# that kuttl can delete the namespace within its timeout. Their Vector sidecar ignores
+# SIGTERM (it is not PID 1) and would linger for the full 300s grace period.
+# The proper fix is in operator-rs (making Vector PID 1 via exec).
+
+# With --skip-delete the namespace is kept for debugging, so this must not run. kuttl does
+# not expose the flag to test steps, hence looking for it in the argv of the kuttl ancestor.
+pid=$(ps -o ppid= -p "$$" 2>/dev/null | tr -d '[:space:]')
+while [ "${pid:-0}" -ge 1 ]; do
+  args=$(ps -o args= -p "$pid" 2>/dev/null)
+  case "$args" in
+    *kuttl*)
+      case "$args" in
+        *--skip-delete*)
+          echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+          exit 0
+          ;;
+      esac
+      ;;
+  esac
+  pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+done
+
+# shellcheck disable=SC2154 # NAMESPACE is set by kuttl for test-step commands
+kubectl delete airflowcluster --all -n "$NAMESPACE" --wait=false 2>/dev/null || true
+
+if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n "$NAMESPACE" --timeout=120s 2>/dev/null; then
+  exit 0
+fi
+kubectl delete pods -l app.kubernetes.io/name=airflow -n "$NAMESPACE" --grace-period=0 --force 2>/dev/null || true
+kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n "$NAMESPACE" --timeout=300s

--- a/tests/templates/kuttl/external-access/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/external-access/90-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/external-access/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/external-access/90-cleanup-executor-pods.yaml.j2
@@ -5,13 +5,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/ldap/99-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/ldap/99-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/ldap/99-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/ldap/99-cleanup-executor-pods.yaml.j2
@@ -5,13 +5,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/logging/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/logging/90-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/logging/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/logging/90-cleanup-executor-pods.yaml.j2
@@ -5,13 +5,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/mount-dags-configmap/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-configmap/90-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/mount-dags-configmap/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-configmap/90-cleanup-executor-pods.yaml.j2
@@ -5,13 +5,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/mount-dags-gitsync/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/90-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/mount-dags-gitsync/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/90-cleanup-executor-pods.yaml.j2
@@ -5,13 +5,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/oidc/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/oidc/90-cleanup-executor-pods.yaml
@@ -4,13 +4,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/oidc/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/oidc/90-cleanup-executor-pods.yaml
@@ -1,40 +1,8 @@
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh

--- a/tests/templates/kuttl/opa/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/opa/90-cleanup-executor-pods.yaml
@@ -4,13 +4,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/opa/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/opa/90-cleanup-executor-pods.yaml
@@ -1,40 +1,8 @@
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh

--- a/tests/templates/kuttl/overrides/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/overrides/90-cleanup-executor-pods.yaml
@@ -4,13 +4,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster --all -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/overrides/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/overrides/90-cleanup-executor-pods.yaml
@@ -1,40 +1,8 @@
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster --all -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh

--- a/tests/templates/kuttl/remote-logging/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/remote-logging/90-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/remote-logging/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/remote-logging/90-cleanup-executor-pods.yaml.j2
@@ -5,13 +5,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
@@ -6,17 +6,34 @@
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
 #
-# FIXME: This step also runs when kuttl is called with --skip-delete, so the
-# AirflowCluster is torn down even though the namespace is kept for debugging.
-# kuttl does not expose --skip-delete to test steps, so there is no clean way to
-# guard against it from here.
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/smoke/90-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/triggerer/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/triggerer/90-cleanup-executor-pods.yaml.j2
@@ -1,42 +1,10 @@
 {% if test_scenario['values']['executor'] == 'kubernetes' %}
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh
 {% endif %}

--- a/tests/templates/kuttl/triggerer/90-cleanup-executor-pods.yaml.j2
+++ b/tests/templates/kuttl/triggerer/90-cleanup-executor-pods.yaml.j2
@@ -5,13 +5,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/versioning/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/versioning/90-cleanup-executor-pods.yaml
@@ -4,13 +4,35 @@
 # sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
 # namespace deletion past kuttl's timeout.
 # The proper fix is in operator-rs (making Vector PID 1 via exec).
+#
+# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
+# teardown must not run. kuttl does not expose the flag to test steps, so it is read
+# from the command line of the kuttl process that invoked this step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
   - script: |
+      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
+      # was started with --skip-delete.
+      pid=$PPID
+      while [ "${pid:-0}" -ge 1 ]; do
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          *kuttl*)
+            case "$args" in
+              *--skip-delete*)
+                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
+                exit 0
+                ;;
+            esac
+            ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+      done
+
       kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-  - script: |
+
       if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
         exit 0
       fi

--- a/tests/templates/kuttl/versioning/90-cleanup-executor-pods.yaml
+++ b/tests/templates/kuttl/versioning/90-cleanup-executor-pods.yaml
@@ -1,40 +1,8 @@
 ---
-# Force-delete KubernetesExecutor DAG task pods before kuttl deletes the namespace.
-# Their Vector sidecar does not respond to SIGTERM (it is not PID 1), so these pods
-# sit in Terminating for the full terminationGracePeriodSeconds (300s), blocking
-# namespace deletion past kuttl's timeout.
-# The proper fix is in operator-rs (making Vector PID 1 via exec).
-#
-# When kuttl runs with --skip-delete the namespace is kept for debugging, so this
-# teardown must not run. kuttl does not expose the flag to test steps, so it is read
-# from the command line of the kuttl process that invoked this step.
+# Force-delete leftover KubernetesExecutor DAG task pods so that kuttl can delete the
+# namespace within its timeout. See the script for the details.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 600
 commands:
-  - script: |
-      # Walk up the process tree (this script is a child of kuttl) and bail out if kuttl
-      # was started with --skip-delete.
-      pid=$PPID
-      while [ "${pid:-0}" -ge 1 ]; do
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *kuttl*)
-            case "$args" in
-              *--skip-delete*)
-                echo "kuttl was started with --skip-delete, keeping the AirflowCluster"
-                exit 0
-                ;;
-            esac
-            ;;
-        esac
-        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-      done
-
-      kubectl delete airflowcluster airflow -n $NAMESPACE --wait=false 2>/dev/null || true
-
-      if kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=120s 2>/dev/null; then
-        exit 0
-      fi
-      kubectl delete pods -l app.kubernetes.io/name=airflow -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
-      kubectl wait --for=delete pod -l app.kubernetes.io/name=airflow -n $NAMESPACE --timeout=300s
+  - script: sh ../../../../templates/kuttl/commons/cleanup-executor-pods.sh


### PR DESCRIPTION
## Description

I ran into this problem enough times to tell claude to fix it

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
