### PR TITLE
fix: Avoid Python import race condition for Kubernetes executor stacklets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   which could cause problems with GitOps tools (e.g. ArgoCD) reporting a diff in the custom resources.
   See [our internal issue](https://github.com/stackabletech/hdfs-operator/issues/626) and [the fix](https://github.com/kube-rs/kube/pull/2042) for details ([#840]).
 - Task logs are served from `BASE_LOG_FOLDER` instead of the `task` handler's `base_log_folder` at the Vector agent log directory ([#834]).
+- Avoid Python import race conditions by pre-cloning the git repo not only for Celery-based stacklets, but also for Kubernetes executor-based setups ([#844]).
 
 [#814]: https://github.com/stackabletech/airflow-operator/pull/814
 [#821]: https://github.com/stackabletech/airflow-operator/pull/821
@@ -40,6 +41,7 @@
 [#834]: https://github.com/stackabletech/airflow-operator/pull/834
 [#835]: https://github.com/stackabletech/airflow-operator/pull/835
 [#840]: https://github.com/stackabletech/airflow-operator/pull/840
+[#844]: https://github.com/stackabletech/airflow-operator/pull/844
 
 ## [26.7.0] - 2026-07-21
 

--- a/docs/modules/airflow/pages/troubleshooting/index.adoc
+++ b/docs/modules/airflow/pages/troubleshooting/index.adoc
@@ -218,16 +218,26 @@ NOTE: Generally speaking it is https://airflow.apache.org/docs/apache-airflow/st
 
 == GitSync race condition
 
-Sometimes a race condition can arise when the long-running Python process started by the Airflow dag-processor caches python submodules before the gitsync fetch is complete. This is indeterminate but can be avoided by adding the following lines to the top of each DAG file that references submodules:
+The operator runs a one-off `git-sync` process in an init container in every Pod, so the repository is guaranteed to be fully cloned before any Airflow process starts.
+A `git-sync` sidecar container then keeps the cloned repository up to date while the Pod is running.
+A race condition can still arise for content that is added to the repository *after* a Pod has started and is delivered by the sidecar: the long-running Python process started by the Airflow dag-processor has cached python submodules and a newly synced submodule may therefore not be found, even though it is already present on disk.
+This is indeterminate but can be avoided by adding the following lines to the top of each DAG file that references submodules:
 
 [source,python]
 ----
 import importlib
 import site
 
-# invalidate cache due to race condition when using dag-processor
+# invalidate import caches so that modules synced after process start are found
 importlib.reload(site)
 importlib.invalidate_caches()
 ----
 
-This will add some overhead that should be minimal in comparison to parsing the DAG as a whole.
+These lines run whenever the DAG file is parsed by the dag-processor or re-parsed for task execution on workers, and add some overhead that should be minimal in comparison to parsing the DAG as a whole.
+
+[NOTE]
+====
+This workaround does not cover the triggerer: the triggerer does not parse DAG files, but imports trigger classes and callables directly at runtime, so code placed in a DAG file never runs in that process.
+If a deferred task references a module that was added to the repository after the triggerer Pod started and fails with `ModuleNotFoundError`, then restarting the triggerer may resolve this.
+This starts a fresh Python process with no stale import caches, and the init container guarantees the repository is fully synced before it starts.
+====

--- a/docs/modules/airflow/pages/usage-guide/mounting-dags.adoc
+++ b/docs/modules/airflow/pages/usage-guide/mounting-dags.adoc
@@ -42,7 +42,8 @@ For multiple DAGs, it is easier to expose them via `gitsync`, as shown below.
 
 == Via `git-sync`
 
-{git-sync}[git-sync] is a command that pulls a git repository into a local directory and is supplied as a sidecar container for use within Kubernetes.
+{git-sync}[git-sync] is a command that pulls a git repository into a local directory.
+The operator runs it twice in each Pod: once in an init container, so that the repository is fully cloned before any Airflow process starts, and again as a sidecar container that keeps the clone up to date (Pods for the Kubernetes executor are short-lived and only get the init container).
 The Stackable Airflow images already ship with git-sync included, and the operator takes care of calling the tool and mounting volumes, so that only the repository and synchronization details are required:
 
 .git-sync usage example: https

--- a/rust/operator-binary/src/controller/build/resource/executor.rs
+++ b/rust/operator-binary/src/controller/build/resource/executor.rs
@@ -29,8 +29,8 @@ use crate::{
             object_meta,
             properties::env_vars::build_airflow_template_envs,
             resource::pod::{
-                add_authentication_volumes_and_volume_mounts, add_git_sync_resources,
-                build_logging_container,
+                GitSyncSidecarsAddition, add_authentication_volumes_and_volume_mounts,
+                add_git_sync_resources, build_logging_container,
             },
             volumes::{self, CONFIG_VOLUME_NAME, LOG_CONFIG_VOLUME_NAME, LOG_VOLUME_NAME},
         },
@@ -143,10 +143,15 @@ pub fn build_executor_template_config_map(
         .add_volume_mount(&*LOG_VOLUME_NAME, STACKABLE_LOG_DIR)
         .context(AddVolumeMountSnafu)?;
 
-    // We don't need a git-sync sidecar, an initial clone via the init-container is sufficient for
-    // Kubernetes executors, as they are short-lived.
-    add_git_sync_resources(&mut pb, &mut airflow_container, git_sync_resources, false)
-        .context(PodSnafu)?;
+    add_git_sync_resources(
+        &mut pb,
+        &mut airflow_container,
+        git_sync_resources,
+        // We don't need a git-sync sidecar, an initial clone via the init-container is sufficient for
+        // Kubernetes executors, as they are short-lived.
+        &GitSyncSidecarsAddition::Skip,
+    )
+    .context(PodSnafu)?;
 
     cluster
         .metadata_database_connection_details()

--- a/rust/operator-binary/src/controller/build/resource/executor.rs
+++ b/rust/operator-binary/src/controller/build/resource/executor.rs
@@ -143,14 +143,10 @@ pub fn build_executor_template_config_map(
         .add_volume_mount(&*LOG_VOLUME_NAME, STACKABLE_LOG_DIR)
         .context(AddVolumeMountSnafu)?;
 
-    add_git_sync_resources(
-        &mut pb,
-        &mut airflow_container,
-        git_sync_resources,
-        false,
-        true,
-    )
-    .context(PodSnafu)?;
+    // We don't need a git-sync sidecar, an initial clone via the init-container is sufficient for
+    // Kubernetes executors, as they are short-lived.
+    add_git_sync_resources(&mut pb, &mut airflow_container, git_sync_resources, false)
+        .context(PodSnafu)?;
 
     cluster
         .metadata_database_connection_details()

--- a/rust/operator-binary/src/controller/build/resource/pod.rs
+++ b/rust/operator-binary/src/controller/build/resource/pod.rs
@@ -93,8 +93,9 @@ pub(crate) fn add_authentication_volumes_and_volume_mounts(
 /// by running a one-off git-sync process in an init-container so that all DAG
 /// dependencies are fully loaded. The sidecar git-sync is then used for regular updates.
 ///
-/// For that reason, we always add a init-container that clones the repo initially. All Pods (except
-/// the Kubernetes operators) additionally use a sidecar to keep the git contents up-to-date.
+/// For that reason, we always add an init-container that clones the repo initially. All Pods
+/// (except the Kubernetes executors) additionally use a sidecar to keep the git contents
+/// up-to-date.
 pub(crate) fn add_git_sync_resources(
     pb: &mut PodBuilder,
     cb: &mut ContainerBuilder,

--- a/rust/operator-binary/src/controller/build/resource/pod.rs
+++ b/rust/operator-binary/src/controller/build/resource/pod.rs
@@ -85,23 +85,31 @@ pub(crate) fn add_authentication_volumes_and_volume_mounts(
     Ok(())
 }
 
+/// Adds the needed git-sync init-container and (optionally) sidecar.
+///
+/// If the DAG is modularized we may encounter a timing issue whereby the main process
+/// has started *before* all modules referenced by the DAG have been fetched by gitsync
+/// and registered. This will result in ModuleNotFoundError errors. This can be avoided
+/// by running a one-off git-sync process in an init-container so that all DAG
+/// dependencies are fully loaded. The sidecar git-sync is then used for regular updates.
+///
+/// For that reason, we always add a init-container that clones the repo initially. All Pods (except
+/// the Kubernetes operators) additionally use a sidecar to keep the git contents up-to-date.
 pub(crate) fn add_git_sync_resources(
     pb: &mut PodBuilder,
     cb: &mut ContainerBuilder,
     git_sync_resources: &git_sync::v1alpha2::GitSyncResources,
     add_sidecar_containers: bool,
-    add_init_containers: bool,
 ) -> Result<()> {
     if add_sidecar_containers {
         for container in git_sync_resources.git_sync_containers.iter().cloned() {
             pb.add_container(container);
         }
     }
-    if add_init_containers {
-        for container in git_sync_resources.git_sync_init_containers.iter().cloned() {
-            pb.add_init_container(container);
-        }
+    for container in git_sync_resources.git_sync_init_containers.iter().cloned() {
+        pb.add_init_container(container);
     }
+
     pb.add_volumes(git_sync_resources.git_content_volumes.to_owned())
         .context(AddVolumeSnafu)?;
     pb.add_volumes(git_sync_resources.git_ssh_volumes.to_owned())

--- a/rust/operator-binary/src/controller/build/resource/pod.rs
+++ b/rust/operator-binary/src/controller/build/resource/pod.rs
@@ -85,6 +85,12 @@ pub(crate) fn add_authentication_volumes_and_volume_mounts(
     Ok(())
 }
 
+#[derive(PartialEq, Eq)]
+pub enum GitSyncSidecarsAddition {
+    Add,
+    Skip,
+}
+
 /// Adds the needed git-sync init-container and (optionally) sidecar.
 ///
 /// If the DAG is modularized we may encounter a timing issue whereby the main process
@@ -100,9 +106,9 @@ pub(crate) fn add_git_sync_resources(
     pb: &mut PodBuilder,
     cb: &mut ContainerBuilder,
     git_sync_resources: &git_sync::v1alpha2::GitSyncResources,
-    add_sidecar_containers: bool,
+    add_sidecar_containers: &GitSyncSidecarsAddition,
 ) -> Result<()> {
-    if add_sidecar_containers {
+    if add_sidecar_containers == &GitSyncSidecarsAddition::Add {
         for container in git_sync_resources.git_sync_containers.iter().cloned() {
             pb.add_container(container);
         }

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -253,20 +253,9 @@ pub fn build_server_rolegroup_statefulset(
             .context(AddVolumeMountSnafu)?;
     }
 
-    // If the DAG is modularized we may encounter a timing issue whereby the celery worker
-    // has started *before* all modules referenced by the DAG have been fetched by gitsync
-    // and registered. This will result in ModuleNotFoundError errors. This can be avoided
-    // by running a one-off git-sync process in an init-container so that all DAG
-    // dependencies are fully loaded. The sidecar git-sync is then used for regular updates.
-    let use_git_sync_init_containers = matches!(executor, AirflowExecutor::CeleryExecutors { .. });
-    add_git_sync_resources(
-        &mut pb,
-        &mut airflow_container,
-        git_sync_resources,
-        true,
-        use_git_sync_init_containers,
-    )
-    .context(PodSnafu)?;
+    // We need a git-sync sidecar to keep the git contents up-to-date
+    add_git_sync_resources(&mut pb, &mut airflow_container, git_sync_resources, true)
+        .context(PodSnafu)?;
 
     validated_cluster
         .metadata_database_connection_details()

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -37,8 +37,8 @@ use crate::{
             properties::env_vars,
             resource::{
                 pod::{
-                    add_authentication_volumes_and_volume_mounts, add_git_sync_resources,
-                    build_logging_container,
+                    GitSyncSidecarsAddition, add_authentication_volumes_and_volume_mounts,
+                    add_git_sync_resources, build_logging_container,
                 },
                 service::stateful_set_service_name,
             },
@@ -253,9 +253,14 @@ pub fn build_server_rolegroup_statefulset(
             .context(AddVolumeMountSnafu)?;
     }
 
-    // We need a git-sync sidecar to keep the git contents up-to-date
-    add_git_sync_resources(&mut pb, &mut airflow_container, git_sync_resources, true)
-        .context(PodSnafu)?;
+    add_git_sync_resources(
+        &mut pb,
+        &mut airflow_container,
+        git_sync_resources,
+        // We need a git-sync sidecar to keep the git contents up-to-date
+        &GitSyncSidecarsAddition::Add,
+    )
+    .context(PodSnafu)?;
 
     validated_cluster
         .metadata_database_connection_details()

--- a/tests/templates/kuttl/ca-cert/25-assert.yaml
+++ b/tests/templates/kuttl/ca-cert/25-assert.yaml
@@ -8,7 +8,10 @@ commands:
       sleep 10
 
       POD="airflow-wrong-cert-dagprocessor-default-0"
-      CONTAINER="git-sync-0"
+      # All Pods clone the repo in an init container, so the git-sync sidecar never gets
+      # started when the CA cert is wrong. Because of this we need to check the init
+      # container instead.
+      CONTAINER="git-sync-0-init"
 
       kubectl logs -n "$NAMESPACE" "$POD" -c "$CONTAINER" 2>/dev/null \
         | grep -q "SSL certificate problem: unable to get local issuer certificate" && exit 0

--- a/tests/templates/kuttl/mount-dags-gitsync/30-assert.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/30-assert.yaml.j2
@@ -9,6 +9,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: airflow-webserver-default
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: git-sync-0-init
 status:
   readyReplicas: 1
   replicas: 1
@@ -18,6 +23,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: airflow-worker-default
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: git-sync-0-init
 status:
   readyReplicas: 1
   replicas: 1
@@ -27,6 +37,37 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: airflow-scheduler-default
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: git-sync-0-init
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airflow-dagprocessor-default
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: git-sync-0-init
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airflow-triggerer-default
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: git-sync-0-init
 status:
   readyReplicas: 1
   replicas: 1

--- a/tests/templates/kuttl/mount-dags-gitsync/30-install-airflow-cluster.yaml.j2
+++ b/tests/templates/kuttl/mount-dags-gitsync/30-install-airflow-cluster.yaml.j2
@@ -181,3 +181,13 @@ spec:
         envOverrides:
           AIRFLOW_CONN_KUBERNETES_IN_CLUSTER: "kubernetes://?__extra__=%7B%22extra__kubernetes__in_cluster%22%3A+true%2C+%22extra__kubernetes__kube_config%22%3A+%22%22%2C+%22extra__kubernetes__kube_config_path%22%3A+%22%22%2C+%22extra__kubernetes__namespace%22%3A+%22%22%7D"
         replicas: 1
+  triggerers:
+    config:
+      gracefulShutdownTimeout: 10s
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    roleGroups:
+      default:
+        envOverrides:
+          AIRFLOW_CONN_KUBERNETES_IN_CLUSTER: "kubernetes://?__extra__=%7B%22extra__kubernetes__in_cluster%22%3A+true%2C+%22extra__kubernetes__kube_config%22%3A+%22%22%2C+%22extra__kubernetes__kube_config_path%22%3A+%22%22%2C+%22extra__kubernetes__namespace%22%3A+%22%22%7D"
+        replicas: 1


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/airflow-operator/issues/732

I noticed this while looking into SUP-396. We already have code in place to prevent Python import race-conditions by pre-cloning the git repo contents before starting the Python processes.
However, that was only done for celery-based stacklets:

```rust
    // If the DAG is modularized we may encounter a timing issue whereby the celery worker
    // has started *before* all modules referenced by the DAG have been fetched by gitsync
    // and registered. This will result in ModuleNotFoundError errors. This can be avoided
    // by running a one-off git-sync process in an init-container so that all DAG
    // dependencies are fully loaded. The sidecar git-sync is then used for regular updates.
    let use_git_sync_init_containers = matches!(executor, AirflowExecutor::CeleryExecutors { .. });
```

While being still on SDP 25.3 (so before our platform fix), the customer in SUP-396 correctly reported that they are using Kubernetes executors, which have the same problem [for anything except executors].

This PR fixes the mechanism to also run on Kubernetes executor-based stacklets

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)

### Release notes

#### Fixed

Previously, there was a race condition importing Python modules from the same Git repo when using git-sync and Kubernetes executors. With this release, we avoid the race conditions by pre-cloning the git repo not only for Celery-based stacklets, but also for Kubernetes executor-based stacklets